### PR TITLE
fix: postgresql tags_to_tagvalues func definition

### DIFF
--- a/storage/postgresql/init.go
+++ b/storage/postgresql/init.go
@@ -17,8 +17,8 @@ func (b *PostgresBackend) Init() error {
 	b.DB = db
 
 	_, err = b.DB.Exec(`
-CREATE FUNCTION tags_to_tagvalues(jsonb) RETURNS text[]
-    AS 'SELECT array_agg(t->>1) FROM (SELECT jsonb_array_elements($1) AS t)s WHERE length(array_agg(t->>0)) = 1;'
+CREATE OR REPLACE FUNCTION tags_to_tagvalues(jsonb) RETURNS text[]
+    AS 'SELECT array_agg(t->>1) FROM (SELECT jsonb_array_elements($1) AS t)s WHERE length(t->>0) = 1;'
     LANGUAGE SQL
     IMMUTABLE
     RETURNS NULL ON NULL INPUT;


### PR DESCRIPTION
There's no need to aggregate an array in order to get the length of the first value in array.

```sql
nostr=# select length(test->>0) from (select jsonb_array_elements('[["p", "42a0825e980b9f97943d2501d99c3a3859d4e68cd6028c02afe58f96ba661a9d", "wss://nostr.bitcoiner.social"]]') as test)t;
 length 
--------
      1
```

```sql
nostr=# select length(test->>0) from (select jsonb_array_elements('[["sup", "42a0825e980b9f97943d2501d99c3a3859d4e68cd6028c02afe58f96ba661a9d", "wss://nostr.bitcoiner.social"]]') as test)t;
 length 
--------
      3
```