### PR TITLE
handle event responses as per NIP-20

### DIFF
--- a/add-event.go
+++ b/add-event.go
@@ -3,6 +3,7 @@ package relayer
 import (
 	"fmt"
 
+	"github.com/fiatjaf/relayer/storage"
 	"github.com/nbd-wtf/go-nostr"
 )
 
@@ -32,7 +33,7 @@ func AddEvent(relay Relay, evt nostr.Event) (accepted bool, message string) {
 	}
 
 	if !relay.AcceptEvent(&evt) {
-		return false, "blocked"
+		return false, "blocked: event blocked by relay"
 	}
 
 	if 20000 <= evt.Kind && evt.Kind < 30000 {
@@ -42,8 +43,13 @@ func AddEvent(relay Relay, evt nostr.Event) (accepted bool, message string) {
 			advancedSaver.BeforeSave(&evt)
 		}
 
-		if err := store.SaveEvent(&evt); err != nil {
-			return false, fmt.Sprintf("error: failed to save: %s", err.Error())
+		if saveErr := store.SaveEvent(&evt); saveErr != nil {
+			switch saveErr {
+			case storage.ErrDupEvent:
+				return true, saveErr.Error()
+			default:
+				return false, fmt.Sprintf("error: failed to save: %s", saveErr.Error())
+			}
 		}
 
 		if advancedSaver != nil {

--- a/rss-bridge/main.go
+++ b/rss-bridge/main.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble"
-	"github.com/nbd-wtf/go-nostr"
 	"github.com/fiatjaf/relayer"
 	"github.com/kelseyhightower/envconfig"
+	"github.com/nbd-wtf/go-nostr"
 )
 
 var relay = &Relay{
@@ -101,9 +101,13 @@ type store struct {
 	db *pebble.DB
 }
 
-func (b store) Init() error                    { return nil }
-func (b store) SaveEvent(_ *nostr.Event) error { return errors.New("we don't accept any events") }
-func (b store) DeleteEvent(_, _ string) error  { return errors.New("we can't delete any events") }
+func (b store) Init() error { return nil }
+func (b store) SaveEvent(_ *nostr.Event) error {
+	return errors.New("blocked: we don't accept any events")
+}
+func (b store) DeleteEvent(_, _ string) error {
+	return errors.New("blocked: we can't delete any events")
+}
 
 func (b store) QueryEvents(filter *nostr.Filter) ([]nostr.Event, error) {
 	var evts []nostr.Event

--- a/storage/errors.go
+++ b/storage/errors.go
@@ -1,0 +1,5 @@
+package storage
+
+import "errors"
+
+var ErrDupEvent = errors.New("duplicate: event already exists")


### PR DESCRIPTION
I got annoyed because my relay keeps showing red dot for writes on [registry page](https://nostr-registry.netlify.app/), eg:

![image](https://user-images.githubusercontent.com/77497807/209356511-7bce1a4e-0acf-4485-b55b-cde1d9cd27a9.png)

This happens when registry page checks for writes, the relay responds with:

```
[
    "OK",
    "41ce9bc50da77dda5542f020370ecc2b056d8f2be93c1cedf1bf57efcab095b0",
    false,
    "error: failed to save: failed to save event 41ce9bc50da77dda5542f020370ecc2b056d8f2be93c1cedf1bf57efcab095b0: pq: duplicate key value violates unique constraint \"ididx\""
]
```

and not with what's written in [NIP-20](https://github.com/nostr-protocol/nips/blob/master/20.md). So while fixing this I took the opportunity to also handle event responses as per NIP-20.

With this fix it responds with:

```
[
    "OK",
    "41ce9bc50da77dda5542f020370ecc2b056d8f2be93c1cedf1bf57efcab095b0",
    true,
    "duplicate: event already exists"
]
```