### PR TITLE
start: make http server's listening host/port compatible with IPv6

### DIFF
--- a/start.go
+++ b/start.go
@@ -1,6 +1,7 @@
 package relayer
 
 import (
+	"net"
 	"net/http"
 	"os"
 	"time"
@@ -69,7 +70,7 @@ func StartConf(s Settings, relay Relay) {
 	// start http server
 	srv := &http.Server{
 		Handler:           cors.Default().Handler(Router),
-		Addr:              s.Host + ":" + s.Port,
+		Addr:              net.JoinHostPort(s.Host, s.Port),
 		WriteTimeout:      2 * time.Second,
 		ReadTimeout:       2 * time.Second,
 		IdleTimeout:       30 * time.Second,


### PR DESCRIPTION
previously, a command like this to listen on IPv6 loopback:

    HOST=::1 PORT=7447 go run ./basic/

would exit immediately because ::1:7447 is an invalid address.

IPv6 addresses contain columns, so a simple host + port concatenation doesn't work. net.JoinHostPort is a function to do exactly that.