### PR TITLE
start: propagate init errors

### DIFF
--- a/basic/main.go
+++ b/basic/main.go
@@ -75,5 +75,7 @@ func main() {
 		return
 	}
 	r.storage = &postgresql.PostgresBackend{DatabaseURL: r.PostgresDatabase}
-	relayer.Start(&r)
+	if err := relayer.Start(&r); err != nil {
+		relayer.Log.Fatal().Err(err).Msg("server terminated")
+	}
 }

--- a/expensive/main.go
+++ b/expensive/main.go
@@ -85,5 +85,7 @@ func main() {
 		return
 	}
 	r.storage = &postgresql.PostgresBackend{DatabaseURL: r.PostgresDatabase}
-	relayer.Start(&r)
+	if err := relayer.Start(&r); err != nil {
+		relayer.Log.Fatal().Err(err).Msg("server terminated")
+	}
 }

--- a/rss-bridge/main.go
+++ b/rss-bridge/main.go
@@ -181,5 +181,7 @@ func (relay *Relay) InjectEvents() chan nostr.Event {
 }
 
 func main() {
-	relayer.Start(relay)
+	if err := relayer.Start(relay); err != nil {
+		relayer.Log.Fatal().Err(err).Msg("server terminated")
+	}
 }

--- a/whitelisted/main.go
+++ b/whitelisted/main.go
@@ -59,5 +59,7 @@ func main() {
 		return
 	}
 	r.storage = &postgresql.PostgresBackend{DatabaseURL: r.PostgresDatabase}
-	relayer.Start(&r)
+	if err := relayer.Start(&r); err != nil {
+		relayer.Log.Fatal().Err(err).Msg("server terminated")
+	}
 }


### PR DESCRIPTION
package users can now act accordingly on startup errors, for example by exiting with a non-zero code. this is useful when running a service, notifying a supervising process about such failures.

although this is technically a breaking change, most pkg users should be unaffected since Start and StartConf returned nothing before this commit.