### PR TITLE
Fix expensive relay invoice handler

### DIFF
--- a/expensive/handler.go
+++ b/expensive/handler.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 )
 
-func handleWebpage(w http.ResponseWriter, r *http.Request) {
+func handleWebpage(w http.ResponseWriter, rq *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 	w.Write([]byte(`
 <meta charset=utf-8>
@@ -53,9 +53,9 @@ body {
     `))
 }
 
-func handleInvoice(w http.ResponseWriter, r *http.Request) {
+func handleInvoice(w http.ResponseWriter, rq *http.Request, r *Relay) {
 	w.Header().Set("Content-Type", "application/json")
-	invoice, err := generateInvoice(r.URL.Query().Get("pubkey"))
+	invoice, err := generateInvoice(r, rq.URL.Query().Get("pubkey"))
 	if err != nil {
 		json.NewEncoder(w).Encode(struct {
 			Error string `json:"error"`

--- a/expensive/lightning.go
+++ b/expensive/lightning.go
@@ -11,7 +11,7 @@ import (
 
 func generateLabel(pubkey string) string { return fmt.Sprintf("relayer-expensive:ticket:%s", pubkey) }
 
-func generateInvoice(pubkey string) (string, error) {
+func generateInvoice(r *Relay, pubkey string) (string, error) {
 	cln := lnsocket.LNSocket{}
 	cln.GenKey()
 

--- a/expensive/main.go
+++ b/expensive/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log"
 	"time"
+	"net/http"
 
 	"github.com/fiatjaf/relayer"
 	"github.com/fiatjaf/relayer/storage/postgresql"
@@ -49,8 +50,12 @@ func (r *Relay) Init() error {
 func (r *Relay) OnInitialized(s *relayer.Server) {
 	// special handlers
 	s.Router().Path("/").HandlerFunc(handleWebpage)
-	s.Router().Path("/invoice").HandlerFunc(handleInvoice)
+	s.Router().Path("/invoice").HandlerFunc(func(w http.ResponseWriter, rq *http.Request) {
+		handleInvoice(w, rq, r)
+	})
 }
+
+
 
 func (r *Relay) AcceptEvent(evt *nostr.Event) bool {
 	// only accept they have a good preimage for a paid invoice for their public key

--- a/expensive/main.go
+++ b/expensive/main.go
@@ -55,8 +55,6 @@ func (r *Relay) OnInitialized(s *relayer.Server) {
 	})
 }
 
-
-
 func (r *Relay) AcceptEvent(evt *nostr.Event) bool {
 	// only accept they have a good preimage for a paid invoice for their public key
 	if !checkInvoicePaidOk(evt.PubKey) {


### PR DESCRIPTION
Fix `malformed public key: invalid length: 0` error on generate invoice request, caused by empty request caused by rewriting of global variable.