### PR TITLE
Remove expired invoice, fix unexpired invoice displaying

### DIFF
--- a/expensive/lightning.go
+++ b/expensive/lightning.go
@@ -28,8 +28,8 @@ func generateInvoice(r *Relay, pubkey string) (string, error) {
 		"label": label,
 	})
 	result, _ := cln.Rpc(r.CLNRune, "listinvoices", string(jparams))
-	timestamp := time.Now().Unix()
 	if gjson.Get(result, "result.invoices.#").Int() == 1 {
+		timestamp := time.Now().Unix()
 		if (gjson.Get(result, "result.invoices.0.expires_at").Int() > timestamp) {
 			return gjson.Get(result, "result.invoices.0.bolt11").String(), nil
 		}


### PR DESCRIPTION
Since CLN require label to be unique , we have 
`Duplicate label 'relayer-expensive:ticket:pubkey'` error,  on attempt to generate invoice for same pubkey twice.

This happens because current `gjson` check condition wrong (for lightningd v 0.12.1). 
So this PR contain fixed condition, and request to remove expired invoice. 

If you don't experience such issues on your side, you may have other version of lightningd , and this PR may be postponed ? 