### PR TITLE
fix: QueryEvents should skip ids that are not a valid 32 byte hex

### DIFF
--- a/storage/postgresql/query.go
+++ b/storage/postgresql/query.go
@@ -32,7 +32,7 @@ func (b PostgresBackend) QueryEvents(filter *nostr.Filter) (events []nostr.Event
 			// to prevent sql attack here we will check if
 			// these ids are valid 32byte hex
 			parsed, err := hex.DecodeString(id)
-			if err != nil || len(parsed) <= 32 {
+			if err != nil || len(parsed) != 32 {
 				continue
 			}
 			likeids = append(likeids, fmt.Sprintf("id LIKE '%x%%'", parsed))


### PR DESCRIPTION
When calling the following:

```
["REQ","nostr-registry",{"ids": "41ce9bc50da77dda5542f020370ecc2b056d8f2be93c1cedf1bf57efcab095b0"]}]
```

relay only responds with:
```
["EOSE","nostr-registry"]
``` 

That is because `41ce9bc50da77dda5542f020370ecc2b056d8f2be93c1cedf1bf57efcab095b0` hex string is 32 bytes long. Because of the `len(parsed) <= 32` we ignored the REQ and didn't subscribe to it.

This change skips ID's whose length `!= 32`.

Does this make sense or am I missing valid ID's whose length can be `> 32` ?