### PR TITLE
fix: remove listeners when client disconnects

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -60,6 +60,7 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 			if _, ok := s.clients[conn]; ok {
 				conn.Close()
 				delete(s.clients, conn)
+				removeListener(ws)
 			}
 			s.clientsMu.Unlock()
 		}()
@@ -214,7 +215,7 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-					removeListener(ws, id)
+					removeListenerId(ws, id)
 					break
 				default:
 					if cwh, ok := s.relay.(CustomWebSocketHandler); ok {

--- a/listener.go
+++ b/listener.go
@@ -63,7 +63,8 @@ func setListener(id string, ws *WebSocket, filters nostr.Filters) {
 	}
 }
 
-func removeListener(ws *WebSocket, id string) {
+// Remove a specific subscription id from listeners for a given ws client
+func removeListenerId(ws *WebSocket, id string) {
 	listenersMutex.Lock()
 	defer func() {
 		listenersMutex.Unlock()
@@ -75,6 +76,17 @@ func removeListener(ws *WebSocket, id string) {
 		if len(subs) == 0 {
 			delete(listeners, ws)
 		}
+	}
+}
+
+// Remove WebSocket conn from listeners
+func removeListener(ws *WebSocket) {
+	listenersMutex.Lock()
+	defer listenersMutex.Unlock()
+
+	_, ok := listeners[ws]
+	if ok {
+		delete(listeners, ws)
 	}
 }
 


### PR DESCRIPTION
We don't remove listeners from memory when client disconnects and keep memory cluttered with it as well as trying to send responses to them despite connection being closed.

### Here's a before/after comparison.

Relay running for ~9h with this fix:
- 296 connected clients
- 614 subscriptions

Relay running for 1h w/o this fix:
- 308 connected clients
- 1757 subscriptions