### PR TITLE
fix: set SetMaxOpenConns, close rows when QueryEvents finishes

### DIFF
--- a/storage/postgresql/init.go
+++ b/storage/postgresql/init.go
@@ -12,6 +12,9 @@ func (b *PostgresBackend) Init() error {
 		return err
 	}
 
+	// sqlx default is 0 (unlimited), while postgresql by default accepts up to 100 connections
+	db.SetMaxOpenConns(80)
+
 	db.Mapper = reflectx.NewMapperFunc("json", sqlx.NameMapper)
 	b.DB = db
 

--- a/storage/postgresql/query.go
+++ b/storage/postgresql/query.go
@@ -139,6 +139,8 @@ func (b PostgresBackend) QueryEvents(filter *nostr.Filter) (events []nostr.Event
 		return nil, fmt.Errorf("failed to fetch events using query %q: %w", query, err)
 	}
 
+	defer rows.Close()
+
 	for rows.Next() {
 		var evt nostr.Event
 		var timestamp int64


### PR DESCRIPTION
By defauly sqlx has no limit on the size of connection pool while postgresql's max connections limit is 100. I've successfully reproduced the error on my local relay node and have pinpointed the issue to relayer not having a connection pool limit. After applying this fix I wasn't able to reproduce the error again. I've also been running this fix on my relay in production for a few hours already and so far didn't see this issue reemerge.

Fixes errors like this one:

```txt
2022/12/30 13:47:58 BasicRelay: store: failed to fetch events using query "SELECT\n      id, pubkey, created_at, kind, tags, content, sig\n    FROM event WHERE kind IN (3) AND tagvalues && ARRAY[$1] ORDER BY cre
ated_at LIMIT 100": dial tcp: lookup localhost: too many open files 
```

Another thing I've noticed is we don't close the rows (included in this commit) which should be as per `sqlx`'s docs:

>  If you do not iterate over a whole rows result, be sure to call rows.Close() to return the connection back to the pool!

sauce: https://jmoiron.github.io/sqlx/#query