### PR TITLE
Small fixes to NIP-42 parts of handlers.go

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -53,7 +53,7 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 	s.clients[conn] = struct{}{}
 	ticker := time.NewTicker(pingPeriod)
 
-	// nip-42 challenge
+	// NIP-42 challenge
 	challenge := make([]byte, 8)
 	rand.Read(challenge)
 
@@ -82,7 +82,7 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 			return nil
 		})
 
-		// nip42 auth challenge
+		// NIP-42 auth challenge
 		if _, ok := s.relay.(Auther); ok {
 			ws.WriteJSON([]interface{}{"AUTH", ws.challenge})
 		}
@@ -260,6 +260,9 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 						}
 						if pubkey, ok := nip42.ValidateAuthEvent(&evt, ws.challenge, auther.ServiceURL()); ok {
 							ws.authed = pubkey
+							ws.WriteJSON([]interface{}{"OK", evt.ID, true, "authentication success"})
+						} else {
+							ws.WriteJSON([]interface{}{"OK", evt.ID, false, "error: failed to authenticate"})
 						}
 					}
 				default:

--- a/handlers.go
+++ b/handlers.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-// TODO: consdier moving these to Server as config params
+// TODO: consider moving these to Server as config params
 const (
 	// Time allowed to write a message to the peer.
 	writeWait = 10 * time.Second
@@ -31,7 +31,7 @@ const (
 	maxMessageSize = 512000
 )
 
-// TODO: consdier moving these to Server as config params
+// TODO: consider moving these to Server as config params
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
@@ -211,7 +211,7 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 								}
 								if (len(senders) == 1 && senders[0] != ws.authed) ||
 									(len(receivers) == 1 && receivers[0] != ws.authed) {
-									notice = "restricted: can't serve kind-4 to their participants"
+									notice = "restricted: can only serve kind-4 to their participants"
 									return
 								}
 							}

--- a/interface.go
+++ b/interface.go
@@ -29,6 +29,8 @@ type Relay interface {
 	Storage() Storage
 }
 
+// Auther is the interface for implementing NIP-42.
+// ServiceURL() returns the URL used to verify the "AUTH" event from clients.
 type Auther interface {
 	ServiceURL() string
 }


### PR DESCRIPTION
Also removed `break` commands at the ends of cases in switch statement, as these are redundant in `go`, cf https://go.dev/tour/flowcontrol/9