### PR TITLE
remove duplicated nip09 handling

### DIFF
--- a/add-event.go
+++ b/add-event.go
@@ -9,28 +9,7 @@ import (
 
 func AddEvent(relay Relay, evt nostr.Event) (accepted bool, message string) {
 	store := relay.Storage()
-	advancedDeleter, _ := store.(AdvancedDeleter)
 	advancedSaver, _ := store.(AdvancedSaver)
-
-	if evt.Kind == 5 {
-		// event deletion -- nip09
-		for _, tag := range evt.Tags {
-			if len(tag) >= 2 && tag[0] == "e" {
-				if advancedDeleter != nil {
-					advancedDeleter.BeforeDelete(tag[1], evt.PubKey)
-				}
-
-				if err := store.DeleteEvent(tag[1], evt.PubKey); err != nil {
-					return false, fmt.Sprintf("error: failed to delete: %s", err.Error())
-				}
-
-				if advancedDeleter != nil {
-					advancedDeleter.AfterDelete(tag[1], evt.PubKey)
-				}
-			}
-		}
-		return true, ""
-	}
 
 	if !relay.AcceptEvent(&evt) {
 		return false, "blocked: event blocked by relay"


### PR DESCRIPTION
NIP09 handling is duplicated between [handlers.go](https://github.com/qustavo/relayer/blob/905a68cd91015df9ae945f383a35b20d3e6e53d9/handlers.go#L156) and [add-event.go](https://github.com/qustavo/relayer/blob/905a68cd91015df9ae945f383a35b20d3e6e53d9/add-event.go#L15).
This PR removes one of those