### PR TITLE
MaxEventSize global server setting

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -137,6 +137,11 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
+					if len(message) > s.settings.MaxEventSize {
+						ws.WriteJSON([]interface{}{"OK", evt.ID, false, "error: invalid event size"})
+						return
+					}
+
 					// check serialization
 					serialized := evt.Serialize()
 


### PR DESCRIPTION
Small optimization to reject messages bigger than a given size threshold.

The idea is that relay implementations won't have to write `AcceptEvent` boilerplate to reject events bigger than a given size, marshaling the event back to a raw json string first, so avoiding something like:

```Go
func (r *Relay) AcceptEvent(evt *nostr.Event) bool {
  jsonb, _ := json.Marshal(evt)
  if len(jsonb) > 10000 {
    return false
  }

  return true
}
```

The server handlers have access to the raw message, so it should be more efficient than marshaling then checking size.

**Note**: This is an experimental idea, as I'm kinda new to relayer, Nostr and its protocol, so I have some doubts about the correctness of all this. Assuming it's acceptable, what would be a sane default?