### PR TITLE
fix ORDER BY

### DIFF
--- a/storage/postgresql/query.go
+++ b/storage/postgresql/query.go
@@ -184,13 +184,13 @@ func (b PostgresBackend) queryEventsSql(filter *nostr.Filter, doCount bool) (str
           COUNT(*)
         FROM event WHERE `+
 			strings.Join(conditions, " AND ")+
-			" ORDER BY created_at DESC LIMIT ?")
+			" LIMIT ?")
 	} else {
 		query = sqlx.Rebind(sqlx.BindType("postgres"), `SELECT
           id, pubkey, created_at, kind, tags, content, sig
         FROM event WHERE `+
 			strings.Join(conditions, " AND ")+
-			" ORDER BY created_at DESC LIMIT ?")
+			" ORDER BY created_at LIMIT ?")
 	}
 
 	return query, params, nil

--- a/storage/sqlite3/query.go
+++ b/storage/sqlite3/query.go
@@ -183,13 +183,13 @@ func queryEventsSql(filter *nostr.Filter, doCount bool) (string, []any, error) {
           COUNT(*)
         FROM event WHERE `+
 			strings.Join(conditions, " AND ")+
-			" ORDER BY created_at DESC LIMIT ?")
+			" LIMIT ?")
 	} else {
 		query = sqlx.Rebind(sqlx.BindType("sqlite3"), `SELECT
           id, pubkey, created_at, kind, tags, content, sig
         FROM event WHERE `+
 			strings.Join(conditions, " AND ")+
-			" ORDER BY created_at DESC LIMIT ?")
+			" ORDER BY created_at LIMIT ?")
 	}
 
 	return query, params, nil


### PR DESCRIPTION
Older events should be submitted first.

```
$ nostreq --kinds 1 | nostcat --stream wss://yabu.me | jq -r '.[2].created_at'
```

This should be ordered by created_at.