### PR TITLE
init the storage before relay

### DIFF
--- a/start.go
+++ b/start.go
@@ -60,12 +60,13 @@ func NewServer(relay Relay) (*Server, error) {
 		serveMux: &http.ServeMux{},
 	}
 
+	if err := relay.Storage(context.Background()).Init(); err != nil {
+		return nil, fmt.Errorf("storage init: %w", err)
+	}
+
 	// init the relay
 	if err := relay.Init(); err != nil {
 		return nil, fmt.Errorf("relay init: %w", err)
-	}
-	if err := relay.Storage(context.Background()).Init(); err != nil {
-		return nil, fmt.Errorf("storage init: %w", err)
 	}
 
 	// start listening from events from other sources, if any


### PR DESCRIPTION
I'd like to init the Storage interface before the before the init of the Relay, that way I can use the storage within the Relay's Init function.

@fiatjaf do you see any issues with doing that?