### PR TITLE
Keep up with the latest specs for since/until filter

### DIFF
--- a/storage/elasticsearch/query.go
+++ b/storage/elasticsearch/query.go
@@ -74,12 +74,12 @@ func buildDsl(filter *nostr.Filter) ([]byte, error) {
 
 	// since
 	if filter.Since != nil {
-		dsl.Must(esquery.Range("event.created_at").Gt(filter.Since))
+		dsl.Must(esquery.Range("event.created_at").Gte(filter.Since))
 	}
 
 	// until
 	if filter.Until != nil {
-		dsl.Must(esquery.Range("event.created_at").Lt(filter.Until))
+		dsl.Must(esquery.Range("event.created_at").Lte(filter.Until))
 	}
 
 	// search

--- a/storage/postgresql/query.go
+++ b/storage/postgresql/query.go
@@ -159,11 +159,11 @@ func (b PostgresBackend) queryEventsSql(filter *nostr.Filter, doCount bool) (str
 	}
 
 	if filter.Since != nil {
-		conditions = append(conditions, "created_at > ?")
+		conditions = append(conditions, "created_at >= ?")
 		params = append(params, filter.Since)
 	}
 	if filter.Until != nil {
-		conditions = append(conditions, "created_at < ?")
+		conditions = append(conditions, "created_at <= ?")
 		params = append(params, filter.Until)
 	}
 

--- a/storage/sqlite3/query.go
+++ b/storage/sqlite3/query.go
@@ -154,11 +154,11 @@ func queryEventsSql(filter *nostr.Filter, doCount bool) (string, []any, error) {
 	}
 
 	if filter.Since != nil {
-		conditions = append(conditions, "created_at > ?")
+		conditions = append(conditions, "created_at >= ?")
 		params = append(params, filter.Since)
 	}
 	if filter.Until != nil {
-		conditions = append(conditions, "created_at < ?")
+		conditions = append(conditions, "created_at <= ?")
 		params = append(params, filter.Until)
 	}
 	if filter.Search != "" {


### PR DESCRIPTION
cf. https://github.com/nostr-protocol/nips/pull/666

This change only affects the filtering of stored events.
As for the filtering of real-time events, it has the `since <= created_at <= until` behavior from the beginning (implementation is [here](https://github.com/nbd-wtf/go-nostr/blob/v0.18.11/filter.go#L66-L72), `!(since > created_at) && !(until < created_at)` is equivalent to the specified condition).