### PR TITLE
feat: basic per-connection soft rate limiter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/stretchr/testify v1.8.0
 	github.com/tidwall/gjson v1.14.4
 	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53
+	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -573,6 +573,7 @@ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.8.0 h1:57P1ETyNKtuIjB4SRd15iJxuhj8Gc416Y78H3qgMh68=
 golang.org/x/text v0.8.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
 golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba h1:O8mE0/t419eoIwhTFpKVkHiTs/Igowgfkj25AcZrtiE=
+golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/websocket.go
+++ b/websocket.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/fasthttp/websocket"
+	"golang.org/x/time/rate"
 )
 
 type WebSocket struct {
@@ -13,6 +14,7 @@ type WebSocket struct {
 	// nip42
 	challenge string
 	authed    string
+	limiter   *rate.Limiter
 }
 
 func (ws *WebSocket) WriteJSON(any interface{}) error {


### PR DESCRIPTION
Adds an optional per-connection token bucket rate limiter. When a connection exceeds the configured rate limit, the limiter will wait until a token is available. This limiter is transparent to clients and will simply throttle incoming messages to protect the relay from being overwhelmed by a single connection. This patch is currently running on the stemstr relay.

Usage:

```diff 
-	server, err := relayer.NewServer(r)
+	opts := []relayer.Option{
+		relayer.WithPerConnectionLimiter(rate.Every(time.Second), 1),
+	}
+
+	server, err := relayer.NewServer(r, opts...)
```

It may also make sense to add another limiter option for a hard rate limiter that will close connections.

Closes #80 