### PR TITLE
fix: do not delete old notes by default

### DIFF
--- a/storage/postgresql/save.go
+++ b/storage/postgresql/save.go
@@ -32,18 +32,6 @@ func (b *PostgresBackend) SaveEvent(ctx context.Context, evt *nostr.Event) error
 	return nil
 }
 
-func (b *PostgresBackend) BeforeSave(ctx context.Context, evt *nostr.Event) {
-	// do nothing
-}
-
-func (b *PostgresBackend) AfterSave(evt *nostr.Event) {
-	// delete all but the 100 most recent ones for each key
-	b.DB.Exec(`DELETE FROM event WHERE pubkey = $1 AND kind = $2 AND created_at < (
-      SELECT created_at FROM event WHERE pubkey = $1
-      ORDER BY created_at DESC OFFSET 100 LIMIT 1
-    )`, evt.PubKey, evt.Kind)
-}
-
 func deleteBeforeSaveSql(evt *nostr.Event) (string, []any, bool) {
 	// react to different kinds of events
 	var (

--- a/storage/sqlite3/save.go
+++ b/storage/sqlite3/save.go
@@ -48,15 +48,3 @@ func (b *SQLite3Backend) SaveEvent(ctx context.Context, evt *nostr.Event) error 
 
 	return nil
 }
-
-func (b *SQLite3Backend) BeforeSave(ctx context.Context, evt *nostr.Event) {
-	// do nothing
-}
-
-func (b *SQLite3Backend) AfterSave(evt *nostr.Event) {
-	// delete all but the 100 most recent ones for each key
-	b.DB.Exec(`DELETE FROM event WHERE pubkey = $1 AND kind = $2 AND created_at < (
-      SELECT created_at FROM event WHERE pubkey = $1
-      ORDER BY created_at DESC OFFSET 100 LIMIT 1
-    )`, evt.PubKey, evt.Kind)
-}


### PR DESCRIPTION
I spent an embarrassing amount of time tracking down why old notes were disappearing. This is a footgun and should not be the default behavior.