### PR TITLE
do not make timeout for reading chan for NIP-5

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -89,12 +89,7 @@ func (s *Server) doEvent(ctx context.Context, ws *WebSocket, request []json.RawM
 					return ""
 				}
 
-				var target *nostr.Event
-				exists := false
-				select {
-				case target, exists = <-res:
-				case <-time.After(time.Millisecond * 200):
-				}
+				target, exists := <-res
 				if !exists {
 					// this will happen if event is not in the database
 					// or when when the query is taking too long, so we just give up


### PR DESCRIPTION
The timeout may make memory leak of chan since the chan is not pulled out. This may be leak of result set.