### PR TITLE
verify event id instead of silently reassigning

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -64,8 +64,7 @@ func (s *Server) doEvent(ctx context.Context, ws *WebSocket, request []json.RawM
 
 	// check id
 	hash := sha256.Sum256(evt.Serialize())
-	id := hex.EncodeToString(hash[:])
-	if id != evt.ID {
+	if id := hex.EncodeToString(hash[:]); id != evt.ID {
 		reason := "invalid: event id is computed incorrectly"
 		ws.WriteJSON(nostr.OKEnvelope{EventID: evt.ID, OK: false, Reason: &reason})
 		return ""


### PR DESCRIPTION
before this code would just reassign the event id to the event and check the signature based on that. if the event id was wrong in the first place this could cause the event to be stored with the incorrect id and other incomprehensible issues.