### PR TITLE
feat: Add authed pubkey to ReqAccepter

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -203,7 +203,7 @@ func (s *Server) doReq(ctx context.Context, ws *WebSocket, request []json.RawMes
 	}
 
 	if accepter, ok := s.relay.(ReqAccepter); ok {
-		if !accepter.AcceptReq(ctx, id, filters) {
+		if !accepter.AcceptReq(ctx, id, filters, ws.authed) {
 			return "REQ filters are not accepted"
 		}
 	}

--- a/interface.go
+++ b/interface.go
@@ -32,7 +32,7 @@ type ReqAccepter interface {
 	// AcceptReq is called for every nostr request filters received by the
 	// server. If the returned value is true, the filtres is passed on to
 	// [Storage.QueryEvent].
-	AcceptReq(context.Context, string, nostr.Filters) bool
+	AcceptReq(ctx context.Context, id string, filters nostr.Filters, authedPubkey string) bool
 }
 
 // Auther is the interface for implementing NIP-42.


### PR DESCRIPTION
Pass the nip-42 pubkey to the ReqAccepter. This allows a relay to authenticate REQs.