### PR TITLE
feat: WithAuthDeadline server option

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -423,14 +423,16 @@ func (s *Server) HandleWebsocket(w http.ResponseWriter, r *http.Request) {
 
 	// writer
 	go func() {
+		authDeadline := make(chan any, 1)
+
 		defer func() {
 			ticker.Stop()
 			conn.Close()
+			close(authDeadline)
 			for range stop {
 			}
 		}()
 
-		authDeadline := make(chan any, 1)
 		go func() {
 			if s.options.authDeadline == nil {
 				return
@@ -441,7 +443,6 @@ func (s *Server) HandleWebsocket(w http.ResponseWriter, r *http.Request) {
 
 			<-time.After(*s.options.authDeadline)
 			authDeadline <- struct{}{}
-			close(authDeadline)
 		}()
 
 		for {

--- a/start.go
+++ b/start.go
@@ -157,11 +157,18 @@ func (s *Server) Shutdown(ctx context.Context) {
 type Option func(*Options)
 
 type Options struct {
+	authDeadline         *time.Duration
 	perConnectionLimiter *rate.Limiter
 }
 
 func DefaultOptions() *Options {
 	return &Options{}
+}
+
+func WithAuthDeadline(deadline time.Duration) Option {
+	return func(o *Options) {
+		o.authDeadline = &deadline
+	}
 }
 
 func WithPerConnectionLimiter(rps rate.Limit, burst int) Option {


### PR DESCRIPTION
WithAuthDeadline provides an option for relays to proactively close connections if a NIP-42 auth challenge is not completed within the specified time.Duration.

Example usage:

```
relayer.NewServer(r, relayer.WithAuthDeadline(time.Second*5)
```