### PR TITLE
use eventstore.RelayWrapper

### DIFF
--- a/add-event.go
+++ b/add-event.go
@@ -18,6 +18,9 @@ func AddEvent(ctx context.Context, relay Relay, evt *nostr.Event) (accepted bool
 	}
 
 	store := relay.Storage(ctx)
+	wrapper := &eventstore.RelayWrapper{
+		Store: store,
+	}
 	advancedSaver, _ := store.(AdvancedSaver)
 
 	if !relay.AcceptEvent(ctx, evt) {
@@ -31,7 +34,7 @@ func AddEvent(ctx context.Context, relay Relay, evt *nostr.Event) (accepted bool
 			advancedSaver.BeforeSave(ctx, evt)
 		}
 
-		if saveErr := store.SaveEvent(ctx, evt); saveErr != nil {
+		if saveErr := wrapper.Publish(ctx, *evt); saveErr != nil {
 			switch saveErr {
 			case eventstore.ErrDupEvent:
 				return true, saveErr.Error()


### PR DESCRIPTION
relayer does not handle kind 0, 3, or 10000-20000, 30000-40000 replacable events. It should be used eventstore.RelayWrapper.Publish.
