### PR TITLE
fix: don't log normal closures as unexpected

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -406,6 +406,7 @@ func (s *Server) HandleWebsocket(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				if websocket.IsUnexpectedCloseError(
 					err,
+					websocket.CloseNormalClosure,    // 1000
 					websocket.CloseGoingAway,        // 1001
 					websocket.CloseNoStatusReceived, // 1005
 					websocket.CloseAbnormalClosure,  // 1006


### PR DESCRIPTION
Normal closures (1000) are currently logged as: 

`unexpected close error from %s: %v`

https://datatracker.ietf.org/doc/html/rfc6455#section-11.7

This PR adds code 1000 to the list of expected codes to prevent these logs lines from polluting the logs. 