### PR TITLE
[DO NOT MERGE] Recreates a map whose size has been emptied, possibly containing an increment.

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -379,13 +379,8 @@ func (s *Server) HandleWebsocket(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			cancel()
 			ticker.Stop()
-			s.clientsMu.Lock()
-			if _, ok := s.clients[conn]; ok {
-				conn.Close()
-				delete(s.clients, conn)
-				removeListener(ws)
-			}
-			s.clientsMu.Unlock()
+			s.deleteClient(conn)
+			removeListener(ws)
 			s.Log.Infof("disconnected from %s", ip)
 		}()
 

--- a/listener.go
+++ b/listener.go
@@ -78,6 +78,9 @@ func removeListener(ws *WebSocket) {
 	defer listenersMutex.Unlock()
 	clear(listeners[ws])
 	delete(listeners, ws)
+	if len(listeners) == 0 {
+		listeners = make(map[*WebSocket]map[string]*Listener)
+	}
 }
 
 func notifyListeners(event *nostr.Event) {

--- a/start.go
+++ b/start.go
@@ -134,6 +134,18 @@ func (s *Server) Start(host string, port int, started ...chan bool) error {
 	}
 }
 
+func (s *Server) deleteClient(conn *websocket.Conn) {
+	s.clientsMu.Lock()
+	if _, ok := s.clients[conn]; ok {
+		conn.Close()
+		delete(s.clients, conn)
+		if len(s.clients) == 0 {
+			s.clients = make(map[*websocket.Conn]struct{})
+		}
+	}
+	s.clientsMu.Unlock()
+}
+
 // Shutdown sends a websocket close control message to all connected clients.
 //
 // If the relay is ShutdownAware, Shutdown calls its OnShutdown, passing the context as is.


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e2afaa24-d884-4309-88c3-a1ae4a9402ac)

Look at this graph. This is a graph of nostr-relay's memory usage. nostr-relay uses relayer. Although there is no particular implementation to increase memory, the graph shows that the memory usage is increasing while releasing memory by GC little by little and increasing the swing of the memory usage.

I'm guessing this is an increase in the capacity of the listeners variable. In general, slices and maps will grow proportionally in size. This change is just a guess, I haven't checked it.
What do you think?