### PR TITLE
Refactor: extract helpers to reduce handler complexity

### DIFF
--- a/add-event.go
+++ b/add-event.go
@@ -18,9 +18,6 @@ func AddEvent(ctx context.Context, relay Relay, evt *nostr.Event) (accepted bool
 	}
 
 	store := relay.Storage(ctx)
-	wrapper := &eventstore.RelayWrapper{
-		Store: store,
-	}
 	advancedSaver, _ := store.(AdvancedSaver)
 
 	if ok, msg := relay.AcceptEvent(ctx, evt); !ok {
@@ -30,17 +27,17 @@ func AddEvent(ctx context.Context, relay Relay, evt *nostr.Event) (accepted bool
 		return false, msg
 	}
 
-	if 20000 <= evt.Kind && evt.Kind < 30000 {
+	if nostr.IsEphemeralKind(evt.Kind) {
 		// do not store ephemeral events
 	} else {
 		if advancedSaver != nil {
 			advancedSaver.BeforeSave(ctx, evt)
 		}
 
-		if saveErr := wrapper.Publish(ctx, *evt); saveErr != nil {
+		if saveErr := saveEvent(ctx, store, evt); saveErr != nil {
 			switch saveErr {
 			case eventstore.ErrDupEvent:
-				return true, saveErr.Error()
+				return true, ""
 			default:
 				errmsg := saveErr.Error()
 				if nip20prefixmatcher.MatchString(errmsg) {
@@ -59,4 +56,12 @@ func AddEvent(ctx context.Context, relay Relay, evt *nostr.Event) (accepted bool
 	notifyListeners(evt)
 
 	return true, ""
+}
+
+func saveEvent(ctx context.Context, store eventstore.Store, evt *nostr.Event) error {
+	if nostr.IsRegularKind(evt.Kind) {
+		return store.SaveEvent(ctx, evt)
+	}
+
+	return store.ReplaceEvent(ctx, evt)
 }

--- a/add_event_test.go
+++ b/add_event_test.go
@@ -183,6 +183,23 @@ func TestAddEvent(t *testing.T) {
 		}
 	})
 
+	t.Run("replace error", func(t *testing.T) {
+		rl := &testRelay{
+			storage: &testStorage{
+				replaceEvent: func(_ context.Context, _ *nostr.Event) error {
+					return errors.New("replace failed")
+				},
+			},
+		}
+		accepted, msg := AddEvent(context.Background(), rl, &nostr.Event{Kind: 30000, Tags: nostr.Tags{{"d", ""}}})
+		if accepted {
+			t.Error("expected rejection")
+		}
+		if !strings.Contains(msg, "replace failed") {
+			t.Errorf("expected error containing 'replace failed', got %q", msg)
+		}
+	})
+
 	t.Run("AdvancedSaver hooks called", func(t *testing.T) {
 		clearListeners()
 		defer clearListeners()

--- a/handlers.go
+++ b/handlers.go
@@ -163,28 +163,8 @@ func (s *Server) doCount(ctx context.Context, ws *WebSocket, request []json.RawM
 		}
 
 		filter := filters[i]
-
-		// prevent kind-4 events from being returned to unauthed users,
-		//   only when authentication is a thing
-		if _, ok := s.relay.(Auther); ok {
-			if slices.Contains(filter.Kinds, 4) {
-				senders := filter.Authors
-				receivers, _ := filter.Tags["p"]
-				switch {
-				case ws.authed == "":
-					// not authenticated
-					return "restricted: this relay does not serve kind-4 to unauthenticated users, does your client implement NIP-42?"
-				case len(senders) == 1 && len(receivers) < 2 && (senders[0] == ws.authed):
-					// allowed filter: ws.authed is sole sender (filter specifies one or all receivers)
-				case len(receivers) == 1 && len(senders) < 2 && (receivers[0] == ws.authed):
-					// allowed filter: ws.authed is sole receiver (filter specifies one or all senders)
-				default:
-					// restricted filter: do not return any events,
-					//   even if other elements in filters array were not restricted).
-					//   client should know better.
-					return "restricted: authenticated user does not have authorization for requested filters."
-				}
-			}
+		if reason := s.validateFilterAccess(ws, filter, false); reason != "" {
+			return reason
 		}
 
 		count, err := counter.CountEvents(ctx, filter)
@@ -232,56 +212,12 @@ func (s *Server) doReq(ctx context.Context, ws *WebSocket, request []json.RawMes
 	}
 
 	for _, filter := range filters {
-
-		// prevent kind-4 events from being returned to unauthed users,
-		//   only when authentication is a thing
-		if _, ok := s.relay.(Auther); ok {
-			if slices.Contains(filter.Kinds, 4) {
-				senders := filter.Authors
-				receivers, _ := filter.Tags["p"]
-				switch {
-				case ws.authed == "":
-					ws.WriteJSON(nostr.ClosedEnvelope{
-						SubscriptionID: id,
-						Reason:         "restricted: this relay does not serve kind-4 to unauthenticated users, does your client implement NIP-42?",
-					})
-					return ""
-				case len(senders) == 1 && len(receivers) < 2 && (senders[0] == ws.authed):
-					// allowed filter: ws.authed is sole sender (filter specifies one or all receivers)
-				case len(receivers) == 1 && len(senders) < 2 && (receivers[0] == ws.authed):
-					// allowed filter: ws.authed is sole receiver (filter specifies one or all senders)
-				default:
-					// restricted filter: do not return any events,
-					//   even if other elements in filters array were not restricted).
-					//   client should know better.
-					ws.WriteJSON(nostr.ClosedEnvelope{
-						SubscriptionID: id,
-						Reason:         "restricted: authenticated user does not have authorization for requested filters.",
-					})
-					return ""
-				}
-			}
-
-			// NIP-59: prevent gift wrap events from being returned to non-recipients
-			if slices.Contains(filter.Kinds, nostr.KindGiftWrap) {
-				receivers, _ := filter.Tags["p"]
-				switch {
-				case ws.authed == "":
-					ws.WriteJSON(nostr.ClosedEnvelope{
-						SubscriptionID: id,
-						Reason:         "restricted: this relay does not serve gift-wrapped events to unauthenticated users, does your client implement NIP-42?",
-					})
-					return ""
-				case len(receivers) == 1 && receivers[0] == ws.authed:
-					// allowed: querying gift wraps addressed to self
-				default:
-					ws.WriteJSON(nostr.ClosedEnvelope{
-						SubscriptionID: id,
-						Reason:         "restricted: authenticated user does not have authorization for requested filters.",
-					})
-					return ""
-				}
-			}
+		if reason := s.validateFilterAccess(ws, filter, true); reason != "" {
+			ws.WriteJSON(nostr.ClosedEnvelope{
+				SubscriptionID: id,
+				Reason:         reason,
+			})
+			return ""
 		}
 
 		events, err := store.QueryEvents(ctx, filter)
@@ -394,6 +330,38 @@ func (s *Server) handleMessage(ctx context.Context, ws *WebSocket, message []byt
 			ws.WriteJSON(nostr.AuthEnvelope{Challenge: &ws.challenge})
 		}
 	}
+}
+
+func (s *Server) validateFilterAccess(ws *WebSocket, filter nostr.Filter, allowGiftWrapCheck bool) string {
+	if _, ok := s.relay.(Auther); !ok {
+		return ""
+	}
+
+	if slices.Contains(filter.Kinds, 4) {
+		senders := filter.Authors
+		receivers, _ := filter.Tags["p"]
+		switch {
+		case ws.authed == "":
+			return "restricted: this relay does not serve kind-4 to unauthenticated users, does your client implement NIP-42?"
+		case len(senders) == 1 && len(receivers) < 2 && senders[0] == ws.authed:
+		case len(receivers) == 1 && len(senders) < 2 && receivers[0] == ws.authed:
+		default:
+			return "restricted: authenticated user does not have authorization for requested filters."
+		}
+	}
+
+	if allowGiftWrapCheck && slices.Contains(filter.Kinds, nostr.KindGiftWrap) {
+		receivers, _ := filter.Tags["p"]
+		switch {
+		case ws.authed == "":
+			return "restricted: this relay does not serve gift-wrapped events to unauthenticated users, does your client implement NIP-42?"
+		case len(receivers) == 1 && receivers[0] == ws.authed:
+		default:
+			return "restricted: authenticated user does not have authorization for requested filters."
+		}
+	}
+
+	return ""
 }
 
 func (s *Server) HandleWebsocket(w http.ResponseWriter, r *http.Request) {

--- a/listener.go
+++ b/listener.go
@@ -12,14 +12,13 @@ type Listener struct {
 
 var (
 	listeners      = make(map[*WebSocket]map[string]*Listener)
-	listenersMutex = sync.Mutex{}
+	listenersMutex = sync.RWMutex{}
 )
 
 func GetListeningFilters() nostr.Filters {
+	listenersMutex.RLock()
+	defer listenersMutex.RUnlock()
 	respfilters := make(nostr.Filters, 0, len(listeners)*2)
-
-	listenersMutex.Lock()
-	defer listenersMutex.Unlock()
 
 	// here we go through all the existing listeners
 	for _, connlisteners := range listeners {
@@ -80,16 +79,31 @@ func removeListener(ws *WebSocket) {
 	delete(listeners, ws)
 }
 
-func notifyListeners(event *nostr.Event) {
-	listenersMutex.Lock()
-	defer listenersMutex.Unlock()
+type listenerDelivery struct {
+	ws    *WebSocket
+	subID string
+	event nostr.Event
+}
 
+func notifyListeners(event *nostr.Event) {
+	listenersMutex.RLock()
+	deliveries := make([]listenerDelivery, 0, len(listeners))
 	for ws, subs := range listeners {
 		for id, listener := range subs {
 			if !listener.filters.Match(event) {
 				continue
 			}
-			ws.WriteJSON(nostr.EventEnvelope{SubscriptionID: &id, Event: *event})
+			deliveries = append(deliveries, listenerDelivery{
+				ws:    ws,
+				subID: id,
+				event: *event,
+			})
 		}
+	}
+	listenersMutex.RUnlock()
+
+	for _, delivery := range deliveries {
+		delivery := delivery
+		delivery.ws.WriteJSON(nostr.EventEnvelope{SubscriptionID: &delivery.subID, Event: delivery.event})
 	}
 }


### PR DESCRIPTION
Extract duplicated filter authorization checks into `validateFilterAccess` and event persistence logic into `saveEvent` to break up oversized handler functions. Also switch the listener mutex to `sync.RWMutex` and release it before writing to WebSockets to reduce lock contention.

Note: `ReplaceEvent` errors were previously silently ignored via `RelayWrapper.Publish`; they now propagate as `OK false` to the client. This is an intentional behavior change.