### PR TITLE
Add NIP-77 (Negentropy) sync support

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -317,6 +317,12 @@ func (s *Server) handleMessage(ctx context.Context, ws *WebSocket, message []byt
 		notice = s.doClose(ctx, ws, request, store)
 	case "AUTH":
 		notice = s.doAuth(ctx, ws, request, store)
+	case "NEG-OPEN":
+		s.doNegOpen(ctx, ws, message, store)
+	case "NEG-MSG":
+		s.doNegMsg(ws, message)
+	case "NEG-CLOSE":
+		s.doNegClose(ws, message)
 	default:
 		if cwh, ok := s.relay.(CustomWebSocketHandler); ok {
 			cwh.HandleUnknownType(ws, typ, request)
@@ -407,6 +413,7 @@ func (s *Server) HandleWebsocket(w http.ResponseWriter, r *http.Request) {
 				conn.Close()
 				delete(s.clients, conn)
 				s.removeListener(ws)
+				ws.clearNegs()
 			}
 			s.clientsMu.Unlock()
 			s.Log.Infof("disconnected from %s", ip)
@@ -482,7 +489,7 @@ func (s *Server) HandleNIP11(w http.ResponseWriter, r *http.Request) {
 	if ifmer, ok := s.relay.(Informationer); ok {
 		info = ifmer.GetNIP11InformationDocument()
 	} else {
-		supportedNIPs := []any{9, 11, 12, 15, 16, 20, 33}
+		supportedNIPs := []any{9, 11, 12, 15, 16, 20, 33, 77}
 		if _, ok := s.relay.(Auther); ok {
 			supportedNIPs = append(supportedNIPs, 42)
 		}

--- a/handlers.go
+++ b/handlers.go
@@ -410,6 +410,21 @@ func (s *Server) handleMessage(ctx context.Context, ws *WebSocket, message []byt
 			ws.WriteJSON(nostr.NoticeEnvelope(notice))
 		}
 		return
+	} else if typ == "NEG-OPEN" || typ == "NEG-MSG" || typ == "NEG-CLOSE" {
+		// NIP-77 is a lock-step protocol: each NEG-MSG answers the frame the
+		// relay just sent, and Reconcile carries state from one frame to the
+		// next. Handing these to workers would let a NEG-MSG overtake its
+		// NEG-OPEN, or a NEG-CLOSE overtake either, so they run here in
+		// receive order like CLOSE does.
+		switch typ {
+		case "NEG-OPEN":
+			s.doNegOpen(ctx, ws, message, store)
+		case "NEG-MSG":
+			s.doNegMsg(ws, message)
+		case "NEG-CLOSE":
+			s.doNegClose(ws, message)
+		}
+		return
 	}
 	go s.handleParsedMessage(ctx, ws, request, store, typ, req)
 }
@@ -527,6 +542,7 @@ func (s *Server) HandleWebsocket(w http.ResponseWriter, r *http.Request) {
 			}
 			s.clientsMu.Unlock()
 			s.removeListener(ws)
+			ws.clearNegs()
 			s.Log.Infof("disconnected from %s", ip)
 		}()
 
@@ -603,7 +619,7 @@ func (s *Server) HandleNIP11(w http.ResponseWriter, r *http.Request) {
 	if ifmer, ok := s.relay.(Informationer); ok {
 		info = ifmer.GetNIP11InformationDocument()
 	} else {
-		supportedNIPs := []any{9, 11, 12, 15, 16, 20, 33, 67}
+		supportedNIPs := []any{9, 11, 12, 15, 16, 20, 33, 67, 77}
 		if _, ok := s.relay.(Auther); ok {
 			// NIP-42 authentication gates private direct messages and
 			// gift-wrapped events, which relayer handles for Auther relays.

--- a/nip77.go
+++ b/nip77.go
@@ -1,0 +1,136 @@
+// NIP-77 Negentropy set-reconciliation server-side handling.
+// The relay replies to NEG-OPEN / NEG-MSG exchanges by iteratively calling
+// negentropy.Reconcile on a frozen snapshot of the events matching the filter.
+package relayer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fiatjaf/eventstore"
+	"github.com/nbd-wtf/go-nostr"
+	"github.com/nbd-wtf/go-nostr/nip77"
+	"github.com/nbd-wtf/go-nostr/nip77/negentropy"
+	"github.com/nbd-wtf/go-nostr/nip77/negentropy/storage/vector"
+)
+
+// Upper bound on the size of a single NEG-MSG payload. Reconcile coalesces
+// further work into subsequent frames when this is reached.
+const negFrameSizeLimit = 4096 * 16
+
+func (ws *WebSocket) getNeg(id string) *negentropy.Negentropy {
+	ws.negsMu.Lock()
+	defer ws.negsMu.Unlock()
+	if ws.negs == nil {
+		return nil
+	}
+	return ws.negs[id]
+}
+
+func (ws *WebSocket) setNeg(id string, n *negentropy.Negentropy) {
+	ws.negsMu.Lock()
+	defer ws.negsMu.Unlock()
+	if ws.negs == nil {
+		ws.negs = make(map[string]*negentropy.Negentropy)
+	}
+	ws.negs[id] = n
+}
+
+func (ws *WebSocket) removeNeg(id string) {
+	ws.negsMu.Lock()
+	defer ws.negsMu.Unlock()
+	delete(ws.negs, id)
+}
+
+func (ws *WebSocket) clearNegs() {
+	ws.negsMu.Lock()
+	defer ws.negsMu.Unlock()
+	ws.negs = nil
+}
+
+// doNegOpen starts a negentropy session: snapshot the filtered events into a
+// sorted vector and reply with the first Reconcile output. Access is gated by
+// the same auth/ReqAccepter checks as REQ so NIP-42/NIP-59 restrictions apply.
+func (s *Server) doNegOpen(ctx context.Context, ws *WebSocket, message []byte, store eventstore.Store) {
+	env := &nip77.OpenEnvelope{}
+	if err := env.UnmarshalJSON(message); err != nil {
+		ws.WriteJSON(nip77.ErrorEnvelope{Reason: "failed to decode NEG-OPEN: " + err.Error()})
+		return
+	}
+	if env.SubscriptionID == "" {
+		ws.WriteJSON(nip77.ErrorEnvelope{Reason: "NEG-OPEN missing subscription id"})
+		return
+	}
+
+	if reason := s.validateFilterAccess(ws, env.Filter, true); reason != "" {
+		ws.WriteJSON(nip77.ErrorEnvelope{SubscriptionID: env.SubscriptionID, Reason: reason})
+		return
+	}
+
+	if accepter, ok := s.relay.(ReqAccepter); ok {
+		if !accepter.AcceptReq(ctx, env.SubscriptionID, nostr.Filters{env.Filter}, ws.authed) {
+			ws.WriteJSON(nip77.ErrorEnvelope{SubscriptionID: env.SubscriptionID, Reason: "NEG-OPEN filter not accepted"})
+			return
+		}
+	}
+
+	events, err := store.QueryEvents(ctx, env.Filter)
+	if err != nil {
+		ws.WriteJSON(nip77.ErrorEnvelope{SubscriptionID: env.SubscriptionID, Reason: fmt.Sprintf("failed to query events: %v", err)})
+		return
+	}
+
+	// Build the storage snapshot. Seal sorts by (createdAt, id) and freezes
+	// the set — Reconcile requires a stable ordering across the whole session.
+	vec := vector.New()
+	if events != nil {
+		for evt := range events {
+			if s.options.skipEventFunc != nil && s.options.skipEventFunc(evt) {
+				continue
+			}
+			vec.Insert(evt.CreatedAt, evt.ID)
+		}
+	}
+	vec.Seal()
+
+	// Server-side uses Reconcile directly (no Start); Start is for the
+	// initiator, which the client already did before sending NEG-OPEN.
+	neg := negentropy.New(vec, negFrameSizeLimit)
+	output, err := neg.Reconcile(env.Message)
+	if err != nil {
+		ws.WriteJSON(nip77.ErrorEnvelope{SubscriptionID: env.SubscriptionID, Reason: "reconcile failed: " + err.Error()})
+		return
+	}
+	ws.setNeg(env.SubscriptionID, neg)
+	ws.WriteJSON(nip77.MessageEnvelope{SubscriptionID: env.SubscriptionID, Message: output})
+}
+
+// doNegMsg advances an open session. Reconcile is stateful per instance, so
+// on any error we drop the session — the client must reopen from scratch.
+func (s *Server) doNegMsg(ws *WebSocket, message []byte) {
+	env := &nip77.MessageEnvelope{}
+	if err := env.UnmarshalJSON(message); err != nil {
+		ws.WriteJSON(nip77.ErrorEnvelope{Reason: "failed to decode NEG-MSG: " + err.Error()})
+		return
+	}
+	neg := ws.getNeg(env.SubscriptionID)
+	if neg == nil {
+		ws.WriteJSON(nip77.ErrorEnvelope{SubscriptionID: env.SubscriptionID, Reason: "unknown subscription"})
+		return
+	}
+	output, err := neg.Reconcile(env.Message)
+	if err != nil {
+		ws.removeNeg(env.SubscriptionID)
+		ws.WriteJSON(nip77.ErrorEnvelope{SubscriptionID: env.SubscriptionID, Reason: "reconcile failed: " + err.Error()})
+		return
+	}
+	ws.WriteJSON(nip77.MessageEnvelope{SubscriptionID: env.SubscriptionID, Message: output})
+}
+
+func (s *Server) doNegClose(ws *WebSocket, message []byte) {
+	env := &nip77.CloseEnvelope{}
+	if err := env.UnmarshalJSON(message); err != nil {
+		return
+	}
+	ws.removeNeg(env.SubscriptionID)
+}

--- a/nip77.go
+++ b/nip77.go
@@ -6,6 +6,7 @@ package relayer
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/fiatjaf/eventstore"
 	"github.com/nbd-wtf/go-nostr"
@@ -18,7 +19,17 @@ import (
 // further work into subsequent frames when this is reached.
 const negFrameSizeLimit = 4096 * 16
 
-func (ws *WebSocket) getNeg(id string) *negentropy.Negentropy {
+// negSession wraps a Negentropy instance with a mutex. Reconcile mutates
+// internal state (lastTimestamp in/out), so concurrent calls on the same
+// instance would race — a buggy client sending multiple NEG-MSG frames in
+// flight would trigger it since handleMessage dispatches each frame in its
+// own goroutine.
+type negSession struct {
+	mu  sync.Mutex
+	neg *negentropy.Negentropy
+}
+
+func (ws *WebSocket) getNeg(id string) *negSession {
 	ws.negsMu.Lock()
 	defer ws.negsMu.Unlock()
 	if ws.negs == nil {
@@ -27,13 +38,13 @@ func (ws *WebSocket) getNeg(id string) *negentropy.Negentropy {
 	return ws.negs[id]
 }
 
-func (ws *WebSocket) setNeg(id string, n *negentropy.Negentropy) {
+func (ws *WebSocket) setNeg(id string, sess *negSession) {
 	ws.negsMu.Lock()
 	defer ws.negsMu.Unlock()
 	if ws.negs == nil {
-		ws.negs = make(map[string]*negentropy.Negentropy)
+		ws.negs = make(map[string]*negSession)
 	}
-	ws.negs[id] = n
+	ws.negs[id] = sess
 }
 
 func (ws *WebSocket) removeNeg(id string) {
@@ -95,13 +106,15 @@ func (s *Server) doNegOpen(ctx context.Context, ws *WebSocket, message []byte, s
 
 	// Server-side uses Reconcile directly (no Start); Start is for the
 	// initiator, which the client already did before sending NEG-OPEN.
-	neg := negentropy.New(vec, negFrameSizeLimit)
-	output, err := neg.Reconcile(env.Message)
+	sess := &negSession{neg: negentropy.New(vec, negFrameSizeLimit)}
+	sess.mu.Lock()
+	output, err := sess.neg.Reconcile(env.Message)
+	sess.mu.Unlock()
 	if err != nil {
 		ws.WriteJSON(nip77.ErrorEnvelope{SubscriptionID: env.SubscriptionID, Reason: "reconcile failed: " + err.Error()})
 		return
 	}
-	ws.setNeg(env.SubscriptionID, neg)
+	ws.setNeg(env.SubscriptionID, sess)
 	ws.WriteJSON(nip77.MessageEnvelope{SubscriptionID: env.SubscriptionID, Message: output})
 }
 
@@ -113,12 +126,14 @@ func (s *Server) doNegMsg(ws *WebSocket, message []byte) {
 		ws.WriteJSON(nip77.ErrorEnvelope{Reason: "failed to decode NEG-MSG: " + err.Error()})
 		return
 	}
-	neg := ws.getNeg(env.SubscriptionID)
-	if neg == nil {
+	sess := ws.getNeg(env.SubscriptionID)
+	if sess == nil {
 		ws.WriteJSON(nip77.ErrorEnvelope{SubscriptionID: env.SubscriptionID, Reason: "unknown subscription"})
 		return
 	}
-	output, err := neg.Reconcile(env.Message)
+	sess.mu.Lock()
+	output, err := sess.neg.Reconcile(env.Message)
+	sess.mu.Unlock()
 	if err != nil {
 		ws.removeNeg(env.SubscriptionID)
 		ws.WriteJSON(nip77.ErrorEnvelope{SubscriptionID: env.SubscriptionID, Reason: "reconcile failed: " + err.Error()})

--- a/nip77.go
+++ b/nip77.go
@@ -1,0 +1,172 @@
+// NIP-77 Negentropy set-reconciliation server-side handling.
+// The relay replies to NEG-OPEN / NEG-MSG exchanges by iteratively calling
+// negentropy.Reconcile on a frozen snapshot of the events matching the filter.
+package relayer
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/fiatjaf/eventstore"
+	"github.com/nbd-wtf/go-nostr"
+	"github.com/nbd-wtf/go-nostr/nip77"
+	"github.com/nbd-wtf/go-nostr/nip77/negentropy"
+	"github.com/nbd-wtf/go-nostr/nip77/negentropy/storage/vector"
+)
+
+// Upper bound on the size of a single NEG-MSG payload. Reconcile coalesces
+// further work into subsequent frames when this is reached.
+const negFrameSizeLimit = 4096 * 16
+
+// negSession wraps a Negentropy instance with a mutex. Reconcile mutates
+// internal state (lastTimestamp in/out), so concurrent calls on the same
+// instance would race. NEG-* frames are dispatched in receive order and never
+// concurrently, so the mutex is only a guard against that changing.
+type negSession struct {
+	mu  sync.Mutex
+	neg *negentropy.Negentropy
+}
+
+func (ws *WebSocket) getNeg(id string) *negSession {
+	ws.negsMu.Lock()
+	defer ws.negsMu.Unlock()
+	if ws.negs == nil {
+		return nil
+	}
+	return ws.negs[id]
+}
+
+func (ws *WebSocket) setNeg(id string, sess *negSession) {
+	ws.negsMu.Lock()
+	defer ws.negsMu.Unlock()
+	if ws.negs == nil {
+		ws.negs = make(map[string]*negSession)
+	}
+	ws.negs[id] = sess
+}
+
+func (ws *WebSocket) removeNeg(id string) {
+	ws.negsMu.Lock()
+	defer ws.negsMu.Unlock()
+	delete(ws.negs, id)
+}
+
+func (ws *WebSocket) clearNegs() {
+	ws.negsMu.Lock()
+	defer ws.negsMu.Unlock()
+	ws.negs = nil
+}
+
+// writeNegErr sends a NEG-ERR. go-nostr's nip77.ErrorEnvelope marshals the
+// label as "NEG-ERROR", but NIP-77 specifies "NEG-ERR", so the envelope is
+// built by hand. go-nostr's own parser matches on a "NEG-ERR" prefix, so
+// clients using it still decode this.
+//
+// Reasons follow the NIP-01 form of a machine-readable single word, a colon,
+// and then a human-readable message.
+func writeNegErr(ws *WebSocket, subscriptionID string, reason string) {
+	ws.WriteJSON([]any{"NEG-ERR", subscriptionID, reason})
+}
+
+// doNegOpen starts a negentropy session: snapshot the filtered events into a
+// sorted vector and reply with the first Reconcile output. Access is gated by
+// the same auth/ReqAccepter checks as REQ so NIP-42/NIP-59 restrictions apply.
+func (s *Server) doNegOpen(ctx context.Context, ws *WebSocket, message []byte, store eventstore.Store) {
+	env := &nip77.OpenEnvelope{}
+	if err := env.UnmarshalJSON(message); err != nil {
+		writeNegErr(ws, "", "invalid: failed to decode NEG-OPEN: "+err.Error())
+		return
+	}
+	if env.SubscriptionID == "" {
+		writeNegErr(ws, "", "invalid: NEG-OPEN is missing a subscription id")
+		return
+	}
+
+	// "If a NEG-OPEN is issued for a currently open subscription ID, the
+	// existing subscription is first closed." Drop it up front so that the
+	// error paths below cannot leave a stale session behind either.
+	ws.removeNeg(env.SubscriptionID)
+
+	if reason := s.validateFilterAccess(ws, env.Filter, true); reason != "" {
+		// validateFilterAccess already returns NIP-01 formatted reasons
+		if strings.HasPrefix(reason, "auth-required:") {
+			s.sendAuthChallenge(ws)
+		}
+		writeNegErr(ws, env.SubscriptionID, reason)
+		return
+	}
+
+	if accepter, ok := s.relay.(ReqAccepter); ok {
+		if !accepter.AcceptReq(ctx, env.SubscriptionID, nostr.Filters{env.Filter}, ws.authed) {
+			writeNegErr(ws, env.SubscriptionID, "blocked: NEG-OPEN filter is not accepted")
+			return
+		}
+	}
+
+	events, err := store.QueryEvents(ctx, env.Filter)
+	if err != nil {
+		writeNegErr(ws, env.SubscriptionID, fmt.Sprintf("error: failed to query events: %v", err))
+		return
+	}
+
+	// Build the storage snapshot. Seal sorts by (createdAt, id) and freezes
+	// the set — Reconcile requires a stable ordering across the whole session.
+	vec := vector.New()
+	if events != nil {
+		for evt := range events {
+			if s.options.skipEventFunc != nil && s.options.skipEventFunc(evt) {
+				continue
+			}
+			vec.Insert(evt.CreatedAt, evt.ID)
+		}
+	}
+	vec.Seal()
+
+	// Server-side uses Reconcile directly (no Start); Start is for the
+	// initiator, which the client already did before sending NEG-OPEN.
+	sess := &negSession{neg: negentropy.New(vec, negFrameSizeLimit)}
+	sess.mu.Lock()
+	output, err := sess.neg.Reconcile(env.Message)
+	sess.mu.Unlock()
+	if err != nil {
+		writeNegErr(ws, env.SubscriptionID, "error: reconcile failed: "+err.Error())
+		return
+	}
+	ws.setNeg(env.SubscriptionID, sess)
+	ws.WriteJSON(nip77.MessageEnvelope{SubscriptionID: env.SubscriptionID, Message: output})
+}
+
+// doNegMsg advances an open session. Reconcile is stateful per instance, so
+// on any error we drop the session — per NIP-77 the subscription is considered
+// closed once a NEG-ERR is issued, and the client must reopen from scratch.
+func (s *Server) doNegMsg(ws *WebSocket, message []byte) {
+	env := &nip77.MessageEnvelope{}
+	if err := env.UnmarshalJSON(message); err != nil {
+		writeNegErr(ws, "", "invalid: failed to decode NEG-MSG: "+err.Error())
+		return
+	}
+	sess := ws.getNeg(env.SubscriptionID)
+	if sess == nil {
+		writeNegErr(ws, env.SubscriptionID, "closed: no such negentropy subscription")
+		return
+	}
+	sess.mu.Lock()
+	output, err := sess.neg.Reconcile(env.Message)
+	sess.mu.Unlock()
+	if err != nil {
+		ws.removeNeg(env.SubscriptionID)
+		writeNegErr(ws, env.SubscriptionID, "error: reconcile failed: "+err.Error())
+		return
+	}
+	ws.WriteJSON(nip77.MessageEnvelope{SubscriptionID: env.SubscriptionID, Message: output})
+}
+
+func (s *Server) doNegClose(ws *WebSocket, message []byte) {
+	env := &nip77.CloseEnvelope{}
+	if err := env.UnmarshalJSON(message); err != nil {
+		return
+	}
+	ws.removeNeg(env.SubscriptionID)
+}

--- a/nip77_test.go
+++ b/nip77_test.go
@@ -1,0 +1,192 @@
+package relayer
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/fasthttp/websocket"
+	"github.com/fiatjaf/eventstore/slicestore"
+	"github.com/nbd-wtf/go-nostr"
+	"github.com/nbd-wtf/go-nostr/nip11"
+	"github.com/nbd-wtf/go-nostr/nip77"
+	"github.com/nbd-wtf/go-nostr/nip77/negentropy"
+	"github.com/nbd-wtf/go-nostr/nip77/negentropy/storage/vector"
+)
+
+// seedRelay stores n signed events in-memory and returns them sorted by CreatedAt.
+func seedRelay(t *testing.T, store *slicestore.SliceStore, n int) []*nostr.Event {
+	t.Helper()
+	sk := nostr.GeneratePrivateKey()
+	events := make([]*nostr.Event, 0, n)
+	for i := 0; i < n; i++ {
+		evt := &nostr.Event{
+			Kind:      nostr.KindTextNote,
+			CreatedAt: nostr.Timestamp(1700000000 + i),
+			Content:   "negentropy test",
+			Tags:      nostr.Tags{},
+		}
+		if err := evt.Sign(sk); err != nil {
+			t.Fatalf("sign: %v", err)
+		}
+		if err := store.SaveEvent(context.Background(), evt); err != nil {
+			t.Fatalf("save: %v", err)
+		}
+		events = append(events, evt)
+	}
+	return events
+}
+
+func readNegMessage(t *testing.T, conn *websocket.Conn) nostr.Envelope {
+	t.Helper()
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	_, raw, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("readMessage: %v", err)
+	}
+	env := nip77.ParseNegMessage(raw)
+	if env == nil {
+		t.Fatalf("not a NEG envelope: %s", raw)
+	}
+	return env
+}
+
+func TestNIP77_ReconcileEmptyClient(t *testing.T) {
+	store := &slicestore.SliceStore{}
+	srv := startTestRelay(t, &testRelay{storage: store})
+	defer srv.Shutdown(context.TODO())
+
+	serverEvents := seedRelay(t, store, 5)
+	serverIDs := make(map[string]struct{}, len(serverEvents))
+	for _, e := range serverEvents {
+		serverIDs[e.ID] = struct{}{}
+	}
+
+	conn := dialTestWS(t, srv.Addr)
+
+	// empty client-side storage — server should report all IDs as "theirs, not ours"
+	vec := vector.New()
+	vec.Seal()
+	neg := negentropy.New(vec, 4096)
+	initial := neg.Start()
+
+	filter := nostr.Filter{Kinds: []int{nostr.KindTextNote}}
+	open := nip77.OpenEnvelope{SubscriptionID: "neg1", Filter: filter, Message: initial}
+	openBytes, err := open.MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal open: %v", err)
+	}
+	if err := conn.WriteMessage(websocket.TextMessage, openBytes); err != nil {
+		t.Fatalf("write open: %v", err)
+	}
+
+	collected := make(map[string]struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for id := range neg.HaveNots {
+			collected[id] = struct{}{}
+		}
+		// drain Haves too so goroutines don't block
+		for range neg.Haves {
+		}
+	}()
+
+	for {
+		env := readNegMessage(t, conn)
+		msgEnv, ok := env.(*nip77.MessageEnvelope)
+		if !ok {
+			t.Fatalf("unexpected envelope %s", env.Label())
+		}
+		if msgEnv.SubscriptionID != "neg1" {
+			t.Fatalf("wrong sub id: %s", msgEnv.SubscriptionID)
+		}
+		reply, err := neg.Reconcile(msgEnv.Message)
+		if err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+		if reply == "" {
+			break
+		}
+		msg := nip77.MessageEnvelope{SubscriptionID: "neg1", Message: reply}
+		msgBytes, _ := msg.MarshalJSON()
+		if err := conn.WriteMessage(websocket.TextMessage, msgBytes); err != nil {
+			t.Fatalf("write msg: %v", err)
+		}
+	}
+
+	<-done
+
+	if len(collected) != len(serverIDs) {
+		t.Fatalf("expected %d ids from server, got %d", len(serverIDs), len(collected))
+	}
+	for id := range serverIDs {
+		if _, ok := collected[id]; !ok {
+			t.Errorf("missing id %s", id)
+		}
+	}
+}
+
+func TestNIP77_CloseUnknownSubscription(t *testing.T) {
+	store := &slicestore.SliceStore{}
+	srv := startTestRelay(t, &testRelay{storage: store})
+	defer srv.Shutdown(context.TODO())
+
+	conn := dialTestWS(t, srv.Addr)
+
+	msg := nip77.MessageEnvelope{SubscriptionID: "ghost", Message: "61"}
+	b, _ := msg.MarshalJSON()
+	if err := conn.WriteMessage(websocket.TextMessage, b); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	env := readNegMessage(t, conn)
+	errEnv, ok := env.(*nip77.ErrorEnvelope)
+	if !ok {
+		t.Fatalf("expected NEG-ERROR, got %s", env.Label())
+	}
+	if errEnv.SubscriptionID != "ghost" {
+		t.Errorf("unexpected sub id %q", errEnv.SubscriptionID)
+	}
+	if errEnv.Reason == "" {
+		t.Errorf("empty reason")
+	}
+}
+
+func TestNIP77_AdvertisedInNIP11(t *testing.T) {
+	store := &slicestore.SliceStore{}
+	srv := startTestRelay(t, &testRelay{storage: store})
+	defer srv.Shutdown(context.TODO())
+
+	req, _ := http.NewRequest(http.MethodGet, "http://"+srv.Addr+"/", nil)
+	req.Header.Set("Accept", "application/nostr+json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http: %v", err)
+	}
+	defer resp.Body.Close()
+	var info nip11.RelayInformationDocument
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	found := false
+	for _, n := range info.SupportedNIPs {
+		switch v := n.(type) {
+		case float64:
+			if v == 77 {
+				found = true
+			}
+		case int:
+			if v == 77 {
+				found = true
+			}
+		}
+		if found {
+			break
+		}
+	}
+	if !found {
+		t.Errorf("NIP-77 not advertised, got %v", info.SupportedNIPs)
+	}
+}

--- a/nip77_test.go
+++ b/nip77_test.go
@@ -129,6 +129,47 @@ func TestNIP77_ReconcileEmptyClient(t *testing.T) {
 	}
 }
 
+func TestNIP77_ConcurrentReconcile(t *testing.T) {
+	// Fire several NEG-MSG frames back-to-back on the same subscription to
+	// exercise the per-session lock under -race.
+	store := &slicestore.SliceStore{}
+	srv := startTestRelay(t, &testRelay{storage: store})
+	defer srv.Shutdown(context.TODO())
+	seedRelay(t, store, 3)
+
+	conn := dialTestWS(t, srv.Addr)
+
+	vec := vector.New()
+	vec.Seal()
+	neg := negentropy.New(vec, 4096)
+	initial := neg.Start()
+
+	open := nip77.OpenEnvelope{SubscriptionID: "race", Filter: nostr.Filter{Kinds: []int{nostr.KindTextNote}}, Message: initial}
+	b, _ := open.MarshalJSON()
+	if err := conn.WriteMessage(websocket.TextMessage, b); err != nil {
+		t.Fatalf("write open: %v", err)
+	}
+	env := readNegMessage(t, conn)
+	first, ok := env.(*nip77.MessageEnvelope)
+	if !ok {
+		t.Fatalf("unexpected envelope: %s", env.Label())
+	}
+
+	// Writes go out sequentially (fasthttp/websocket forbids concurrent
+	// writes from one client), but each message spawns its own goroutine on
+	// the server side, so their Reconcile calls can overlap.
+	msg := nip77.MessageEnvelope{SubscriptionID: "race", Message: first.Message}
+	mb, _ := msg.MarshalJSON()
+	for i := 0; i < 8; i++ {
+		if err := conn.WriteMessage(websocket.TextMessage, mb); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	for i := 0; i < 8; i++ {
+		readNegMessage(t, conn)
+	}
+}
+
 func TestNIP77_CloseUnknownSubscription(t *testing.T) {
 	store := &slicestore.SliceStore{}
 	srv := startTestRelay(t, &testRelay{storage: store})

--- a/nip77_test.go
+++ b/nip77_test.go
@@ -1,0 +1,303 @@
+package relayer
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fasthttp/websocket"
+	"github.com/fiatjaf/eventstore/slicestore"
+	"github.com/nbd-wtf/go-nostr"
+	"github.com/nbd-wtf/go-nostr/nip11"
+	"github.com/nbd-wtf/go-nostr/nip77"
+	"github.com/nbd-wtf/go-nostr/nip77/negentropy"
+	"github.com/nbd-wtf/go-nostr/nip77/negentropy/storage/vector"
+)
+
+// seedRelay stores n signed events in-memory and returns them sorted by CreatedAt.
+func seedRelay(t *testing.T, store *slicestore.SliceStore, n int) []*nostr.Event {
+	t.Helper()
+	sk := nostr.GeneratePrivateKey()
+	events := make([]*nostr.Event, 0, n)
+	for i := 0; i < n; i++ {
+		evt := &nostr.Event{
+			Kind:      nostr.KindTextNote,
+			CreatedAt: nostr.Timestamp(1700000000 + i),
+			Content:   "negentropy test",
+			Tags:      nostr.Tags{},
+		}
+		if err := evt.Sign(sk); err != nil {
+			t.Fatalf("sign: %v", err)
+		}
+		if err := store.SaveEvent(context.Background(), evt); err != nil {
+			t.Fatalf("save: %v", err)
+		}
+		events = append(events, evt)
+	}
+	return events
+}
+
+func readNegMessage(t *testing.T, conn *websocket.Conn) nostr.Envelope {
+	t.Helper()
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	_, raw, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("readMessage: %v", err)
+	}
+	env := nip77.ParseNegMessage(raw)
+	if env == nil {
+		t.Fatalf("not a NEG envelope: %s", raw)
+	}
+	return env
+}
+
+func TestNIP77_ReconcileEmptyClient(t *testing.T) {
+	store := &slicestore.SliceStore{}
+	srv := startTestRelay(t, &testRelay{storage: store})
+	defer srv.Shutdown(context.TODO())
+
+	serverEvents := seedRelay(t, store, 5)
+	serverIDs := make(map[string]struct{}, len(serverEvents))
+	for _, e := range serverEvents {
+		serverIDs[e.ID] = struct{}{}
+	}
+
+	conn := dialTestWS(t, srv.Addr)
+
+	// empty client-side storage — server should report all IDs as "theirs, not ours"
+	vec := vector.New()
+	vec.Seal()
+	neg := negentropy.New(vec, 4096)
+	initial := neg.Start()
+
+	filter := nostr.Filter{Kinds: []int{nostr.KindTextNote}}
+	open := nip77.OpenEnvelope{SubscriptionID: "neg1", Filter: filter, Message: initial}
+	openBytes, err := open.MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal open: %v", err)
+	}
+	if err := conn.WriteMessage(websocket.TextMessage, openBytes); err != nil {
+		t.Fatalf("write open: %v", err)
+	}
+
+	collected := make(map[string]struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for id := range neg.HaveNots {
+			collected[id] = struct{}{}
+		}
+		// drain Haves too so goroutines don't block
+		for range neg.Haves {
+		}
+	}()
+
+	for {
+		env := readNegMessage(t, conn)
+		msgEnv, ok := env.(*nip77.MessageEnvelope)
+		if !ok {
+			t.Fatalf("unexpected envelope %s", env.Label())
+		}
+		if msgEnv.SubscriptionID != "neg1" {
+			t.Fatalf("wrong sub id: %s", msgEnv.SubscriptionID)
+		}
+		reply, err := neg.Reconcile(msgEnv.Message)
+		if err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+		if reply == "" {
+			break
+		}
+		msg := nip77.MessageEnvelope{SubscriptionID: "neg1", Message: reply}
+		msgBytes, _ := msg.MarshalJSON()
+		if err := conn.WriteMessage(websocket.TextMessage, msgBytes); err != nil {
+			t.Fatalf("write msg: %v", err)
+		}
+	}
+
+	<-done
+
+	if len(collected) != len(serverIDs) {
+		t.Fatalf("expected %d ids from server, got %d", len(serverIDs), len(collected))
+	}
+	for id := range serverIDs {
+		if _, ok := collected[id]; !ok {
+			t.Errorf("missing id %s", id)
+		}
+	}
+}
+
+func TestNIP77_SequentialReconcileInReceiveOrder(t *testing.T) {
+	// Fire several NEG-MSG frames back-to-back on the same subscription. They
+	// must all be answered, in order, on the session opened by the NEG-OPEN
+	// that preceded them.
+	store := &slicestore.SliceStore{}
+	srv := startTestRelay(t, &testRelay{storage: store})
+	defer srv.Shutdown(context.TODO())
+	seedRelay(t, store, 3)
+
+	conn := dialTestWS(t, srv.Addr)
+
+	vec := vector.New()
+	vec.Seal()
+	neg := negentropy.New(vec, 4096)
+	initial := neg.Start()
+
+	open := nip77.OpenEnvelope{SubscriptionID: "race", Filter: nostr.Filter{Kinds: []int{nostr.KindTextNote}}, Message: initial}
+	b, _ := open.MarshalJSON()
+	if err := conn.WriteMessage(websocket.TextMessage, b); err != nil {
+		t.Fatalf("write open: %v", err)
+	}
+	env := readNegMessage(t, conn)
+	first, ok := env.(*nip77.MessageEnvelope)
+	if !ok {
+		t.Fatalf("unexpected envelope: %s", env.Label())
+	}
+
+	msg := nip77.MessageEnvelope{SubscriptionID: "race", Message: first.Message}
+	mb, _ := msg.MarshalJSON()
+	for i := 0; i < 8; i++ {
+		if err := conn.WriteMessage(websocket.TextMessage, mb); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	for i := 0; i < 8; i++ {
+		env := readNegMessage(t, conn)
+		if _, ok := env.(*nip77.MessageEnvelope); !ok {
+			t.Fatalf("frame %d: expected NEG-MSG, got %s: %s", i, env.Label(), env)
+		}
+	}
+}
+
+// TestNIP77_CloseIsNotReorderedBeforeOpen: a NEG-CLOSE sent immediately after
+// its NEG-OPEN must be applied after it. Handling NEG-* frames on worker
+// goroutines let the cheap close win the race, no-op against a session that
+// did not exist yet, and leave the session that the open then created alive
+// forever. The leak is only visible afterwards: a NEG-MSG on a closed
+// subscription has to be rejected.
+func TestNIP77_CloseIsNotReorderedBeforeOpen(t *testing.T) {
+	store := &slicestore.SliceStore{}
+	srv := startTestRelay(t, &testRelay{storage: store})
+	defer srv.Shutdown(context.TODO())
+	seedRelay(t, store, 20)
+
+	for attempt := 0; attempt < 20; attempt++ {
+		conn := dialTestWS(t, srv.Addr)
+
+		vec := vector.New()
+		vec.Seal()
+		neg := negentropy.New(vec, 4096)
+
+		open := nip77.OpenEnvelope{SubscriptionID: "ord", Filter: nostr.Filter{Kinds: []int{nostr.KindTextNote}}, Message: neg.Start()}
+		ob, _ := open.MarshalJSON()
+		if err := conn.WriteMessage(websocket.TextMessage, ob); err != nil {
+			t.Fatalf("write open: %v", err)
+		}
+		cb, _ := (nip77.CloseEnvelope{SubscriptionID: "ord"}).MarshalJSON()
+		if err := conn.WriteMessage(websocket.TextMessage, cb); err != nil {
+			t.Fatalf("write close: %v", err)
+		}
+
+		env := readNegMessage(t, conn)
+		reply, ok := env.(*nip77.MessageEnvelope)
+		if !ok {
+			t.Fatalf("attempt %d: expected the NEG-OPEN reply, got %s: %s", attempt, env.Label(), env)
+		}
+
+		// the subscription is closed, so this must be refused
+		mb, _ := (nip77.MessageEnvelope{SubscriptionID: "ord", Message: reply.Message}).MarshalJSON()
+		if err := conn.WriteMessage(websocket.TextMessage, mb); err != nil {
+			t.Fatalf("write msg: %v", err)
+		}
+		env = readNegMessage(t, conn)
+		if _, ok := env.(*nip77.ErrorEnvelope); !ok {
+			t.Fatalf("attempt %d: NEG-CLOSE was applied before its NEG-OPEN, leaking the session: got %s: %s", attempt, env.Label(), env)
+		}
+		conn.Close()
+	}
+}
+
+func TestNIP77_CloseUnknownSubscription(t *testing.T) {
+	store := &slicestore.SliceStore{}
+	srv := startTestRelay(t, &testRelay{storage: store})
+	defer srv.Shutdown(context.TODO())
+
+	conn := dialTestWS(t, srv.Addr)
+
+	msg := nip77.MessageEnvelope{SubscriptionID: "ghost", Message: "61"}
+	b, _ := msg.MarshalJSON()
+	if err := conn.WriteMessage(websocket.TextMessage, b); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, raw, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	// NIP-77 spells the error label NEG-ERR; go-nostr's ErrorEnvelope
+	// marshals NEG-ERROR, so assert the raw bytes rather than round-tripping
+	// through the library that has the bug.
+	var arr []string
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		t.Fatalf("decode %s: %v", raw, err)
+	}
+	if len(arr) != 3 {
+		t.Fatalf("expected 3 elements, got %v", arr)
+	}
+	if arr[0] != "NEG-ERR" {
+		t.Errorf("label must be NEG-ERR per NIP-77, got %q", arr[0])
+	}
+	if arr[1] != "ghost" {
+		t.Errorf("unexpected sub id %q", arr[1])
+	}
+	// "a machine-readable single-word prefix, followed by a `:`"
+	word, rest, found := strings.Cut(arr[2], ":")
+	if !found || word == "" || strings.ContainsAny(word, " \t") || strings.TrimSpace(rest) == "" {
+		t.Errorf("reason %q is not in NIP-01 \"word: message\" form", arr[2])
+	}
+
+	// it must still decode as an error for clients using go-nostr's parser
+	if _, ok := nip77.ParseNegMessage(raw).(*nip77.ErrorEnvelope); !ok {
+		t.Errorf("go-nostr does not parse %s as a NEG error", raw)
+	}
+}
+
+func TestNIP77_AdvertisedInNIP11(t *testing.T) {
+	store := &slicestore.SliceStore{}
+	srv := startTestRelay(t, &testRelay{storage: store})
+	defer srv.Shutdown(context.TODO())
+
+	req, _ := http.NewRequest(http.MethodGet, "http://"+srv.Addr+"/", nil)
+	req.Header.Set("Accept", "application/nostr+json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http: %v", err)
+	}
+	defer resp.Body.Close()
+	var info nip11.RelayInformationDocument
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	found := false
+	for _, n := range info.SupportedNIPs {
+		switch v := n.(type) {
+		case float64:
+			if v == 77 {
+				found = true
+			}
+		case int:
+			if v == 77 {
+				found = true
+			}
+		}
+		if found {
+			break
+		}
+	}
+	if !found {
+		t.Errorf("NIP-77 not advertised, got %v", info.SupportedNIPs)
+	}
+}

--- a/websocket.go
+++ b/websocket.go
@@ -4,7 +4,6 @@ import (
 	"sync"
 
 	"github.com/fasthttp/websocket"
-	"github.com/nbd-wtf/go-nostr/nip77/negentropy"
 	"golang.org/x/time/rate"
 )
 
@@ -19,7 +18,7 @@ type WebSocket struct {
 
 	// nip77
 	negsMu sync.Mutex
-	negs   map[string]*negentropy.Negentropy
+	negs   map[string]*negSession
 }
 
 func (ws *WebSocket) WriteJSON(any interface{}) error {

--- a/websocket.go
+++ b/websocket.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/fasthttp/websocket"
+	"github.com/nbd-wtf/go-nostr/nip77/negentropy"
 	"golang.org/x/time/rate"
 )
 
@@ -15,6 +16,10 @@ type WebSocket struct {
 	challenge string
 	authed    string
 	limiter   *rate.Limiter
+
+	// nip77
+	negsMu sync.Mutex
+	negs   map[string]*negentropy.Negentropy
 }
 
 func (ws *WebSocket) WriteJSON(any interface{}) error {

--- a/websocket.go
+++ b/websocket.go
@@ -19,6 +19,10 @@ type WebSocket struct {
 	challenge string
 	authed    string
 	limiter   *rate.Limiter
+
+	// nip77
+	negsMu sync.Mutex
+	negs   map[string]*negSession
 }
 
 func (ws *WebSocket) WriteJSON(any interface{}) error {


### PR DESCRIPTION
Implements server-side handling for `NEG-OPEN`, `NEG-MSG`, and `NEG-CLOSE` so clients can reconcile event sets with the relay without redownloading events they already have. Each session keeps per-subscription negentropy state on the `WebSocket`, snapshots events matching the filter into a sealed vector storage, and drives `Reconcile` per incoming frame. Access is gated by the same `validateFilterAccess` and `ReqAccepter` checks as `REQ`, so NIP-42 and NIP-59 restrictions still apply. NIP-77 is also advertised in the default NIP-11 document.