### PR TITLE
Isolate listeners per server

### DIFF
--- a/add-event.go
+++ b/add-event.go
@@ -53,7 +53,11 @@ func AddEvent(ctx context.Context, relay Relay, evt *nostr.Event) (accepted bool
 		}
 	}
 
-	notifyListeners(evt)
+	if srv, ok := getServer(ctx); ok {
+		srv.notifyListeners(evt)
+	} else {
+		BroadcastEvent(evt)
+	}
 
 	return true, ""
 }

--- a/broadcasting.go
+++ b/broadcasting.go
@@ -4,6 +4,6 @@ import (
 	"github.com/nbd-wtf/go-nostr"
 )
 
-func BroadcastEvent(evt *nostr.Event) {
-	notifyListeners(evt)
+func (s *Server) BroadcastEvent(evt *nostr.Event) {
+	s.notifyListeners(evt)
 }

--- a/extra.go
+++ b/extra.go
@@ -2,7 +2,10 @@ package relayer
 
 import "context"
 
-const AUTH_CONTEXT_KEY = iota
+const (
+	AUTH_CONTEXT_KEY = iota
+	SERVER_CONTEXT_KEY
+)
 
 func GetAuthStatus(ctx context.Context) (pubkey string, ok bool) {
 	value := ctx.Value(AUTH_CONTEXT_KEY)
@@ -13,4 +16,13 @@ func GetAuthStatus(ctx context.Context) (pubkey string, ok bool) {
 		return ws.authed, true
 	}
 	return "", false
+}
+
+func getServer(ctx context.Context) (*Server, bool) {
+	value := ctx.Value(SERVER_CONTEXT_KEY)
+	if value == nil {
+		return nil, false
+	}
+	srv, ok := value.(*Server)
+	return srv, ok
 }

--- a/handlers.go
+++ b/handlers.go
@@ -133,7 +133,7 @@ func (s *Server) doEvent(ctx context.Context, ws *WebSocket, request []json.RawM
 			}
 		}
 
-		notifyListeners(&evt)
+		s.notifyListeners(&evt)
 		ws.WriteJSON(nostr.OKEnvelope{EventID: evt.ID, OK: true})
 		return ""
 	}
@@ -250,7 +250,7 @@ func (s *Server) doReq(ctx context.Context, ws *WebSocket, request []json.RawMes
 	}
 
 	ws.WriteJSON(nostr.EOSEEnvelope(id))
-	setListener(id, ws, filters)
+	s.setListener(id, ws, filters)
 	return ""
 }
 
@@ -261,7 +261,7 @@ func (s *Server) doClose(ctx context.Context, ws *WebSocket, request []json.RawM
 		return "CLOSE has no <id>"
 	}
 
-	removeListenerId(ws, id)
+	s.removeListenerId(ws, id)
 	return ""
 }
 
@@ -304,6 +304,7 @@ func (s *Server) handleMessage(ctx context.Context, ws *WebSocket, message []byt
 	json.Unmarshal(request[0], &typ)
 
 	ctx = context.WithValue(ctx, AUTH_CONTEXT_KEY, ws)
+	ctx = context.WithValue(ctx, SERVER_CONTEXT_KEY, s)
 
 	switch typ {
 	case "EVENT":
@@ -405,7 +406,7 @@ func (s *Server) HandleWebsocket(w http.ResponseWriter, r *http.Request) {
 			if _, ok := s.clients[conn]; ok {
 				conn.Close()
 				delete(s.clients, conn)
-				removeListener(ws)
+				s.removeListener(ws)
 			}
 			s.clientsMu.Unlock()
 			s.Log.Infof("disconnected from %s", ip)

--- a/listener.go
+++ b/listener.go
@@ -1,82 +1,85 @@
 package relayer
 
-import (
-	"sync"
-
-	"github.com/nbd-wtf/go-nostr"
-)
+import "github.com/nbd-wtf/go-nostr"
 
 type Listener struct {
 	filters nostr.Filters
 }
 
-var (
-	listeners      = make(map[*WebSocket]map[string]*Listener)
-	listenersMutex = sync.RWMutex{}
-)
-
 func GetListeningFilters() nostr.Filters {
-	listenersMutex.RLock()
-	defer listenersMutex.RUnlock()
-	respfilters := make(nostr.Filters, 0, len(listeners)*2)
+	serversMutex.RLock()
+	defer serversMutex.RUnlock()
 
-	// here we go through all the existing listeners
-	for _, connlisteners := range listeners {
-		for _, listener := range connlisteners {
-			for _, listenerfilter := range listener.filters {
-				for _, respfilter := range respfilters {
-					// check if this filter specifically is already added to respfilters
-					if nostr.FilterEqual(listenerfilter, respfilter) {
-						goto nextconn
-					}
-				}
-
-				// field not yet present on respfilters, add it
-				respfilters = append(respfilters, listenerfilter)
-
-				// continue to the next filter
-			nextconn:
-				continue
-			}
-		}
+	respfilters := make(nostr.Filters, 0, len(servers)*2)
+	for srv := range servers {
+		respfilters = appendDistinctFilters(respfilters, srv.GetListeningFilters())
 	}
 
-	// respfilters will be a slice with all the distinct filter we currently have active
 	return respfilters
 }
 
-func setListener(id string, ws *WebSocket, filters nostr.Filters) {
-	listenersMutex.Lock()
-	defer listenersMutex.Unlock()
+func (s *Server) GetListeningFilters() nostr.Filters {
+	s.listenersMu.RLock()
+	defer s.listenersMu.RUnlock()
+	respfilters := make(nostr.Filters, 0, len(s.listeners)*2)
 
-	subs, ok := listeners[ws]
+	for _, connlisteners := range s.listeners {
+		for _, listener := range connlisteners {
+			respfilters = appendDistinctFilters(respfilters, listener.filters)
+		}
+	}
+
+	return respfilters
+}
+
+func appendDistinctFilters(dst nostr.Filters, src nostr.Filters) nostr.Filters {
+	for _, listenerfilter := range src {
+		duplicate := false
+		for _, respfilter := range dst {
+			if nostr.FilterEqual(listenerfilter, respfilter) {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			dst = append(dst, listenerfilter)
+		}
+	}
+	return dst
+}
+
+func (s *Server) setListener(id string, ws *WebSocket, filters nostr.Filters) {
+	s.listenersMu.Lock()
+	defer s.listenersMu.Unlock()
+
+	subs, ok := s.listeners[ws]
 	if !ok {
 		subs = make(map[string]*Listener)
-		listeners[ws] = subs
+		s.listeners[ws] = subs
 	}
 
 	subs[id] = &Listener{filters: filters}
 }
 
 // Remove a specific subscription id from listeners for a given ws client
-func removeListenerId(ws *WebSocket, id string) {
-	listenersMutex.Lock()
-	defer listenersMutex.Unlock()
+func (s *Server) removeListenerId(ws *WebSocket, id string) {
+	s.listenersMu.Lock()
+	defer s.listenersMu.Unlock()
 
-	if subs, ok := listeners[ws]; ok {
-		delete(listeners[ws], id)
+	if subs, ok := s.listeners[ws]; ok {
+		delete(s.listeners[ws], id)
 		if len(subs) == 0 {
-			delete(listeners, ws)
+			delete(s.listeners, ws)
 		}
 	}
 }
 
 // Remove WebSocket conn from listeners
-func removeListener(ws *WebSocket) {
-	listenersMutex.Lock()
-	defer listenersMutex.Unlock()
-	clear(listeners[ws])
-	delete(listeners, ws)
+func (s *Server) removeListener(ws *WebSocket) {
+	s.listenersMu.Lock()
+	defer s.listenersMu.Unlock()
+	clear(s.listeners[ws])
+	delete(s.listeners, ws)
 }
 
 type listenerDelivery struct {
@@ -85,10 +88,10 @@ type listenerDelivery struct {
 	event nostr.Event
 }
 
-func notifyListeners(event *nostr.Event) {
-	listenersMutex.RLock()
-	deliveries := make([]listenerDelivery, 0, len(listeners))
-	for ws, subs := range listeners {
+func (s *Server) notifyListeners(event *nostr.Event) {
+	s.listenersMu.RLock()
+	deliveries := make([]listenerDelivery, 0, len(s.listeners))
+	for ws, subs := range s.listeners {
 		for id, listener := range subs {
 			if !listener.filters.Match(event) {
 				continue
@@ -100,10 +103,19 @@ func notifyListeners(event *nostr.Event) {
 			})
 		}
 	}
-	listenersMutex.RUnlock()
+	s.listenersMu.RUnlock()
 
 	for _, delivery := range deliveries {
 		delivery := delivery
 		delivery.ws.WriteJSON(nostr.EventEnvelope{SubscriptionID: &delivery.subID, Event: delivery.event})
+	}
+}
+
+func BroadcastEvent(evt *nostr.Event) {
+	serversMutex.RLock()
+	defer serversMutex.RUnlock()
+
+	for srv := range servers {
+		srv.notifyListeners(evt)
 	}
 }

--- a/listener_test.go
+++ b/listener_test.go
@@ -1,27 +1,36 @@
 package relayer
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
+	"time"
 
+	"github.com/fasthttp/websocket"
+	"github.com/fiatjaf/eventstore/slicestore"
 	"github.com/nbd-wtf/go-nostr"
 )
 
-func listenerCount(ws *WebSocket) int {
-	listenersMutex.Lock()
-	defer listenersMutex.Unlock()
-	return len(listeners[ws])
+func newListenerTestServer() *Server {
+	return &Server{listeners: make(map[*WebSocket]map[string]*Listener)}
 }
 
-func totalConnections() int {
-	listenersMutex.Lock()
-	defer listenersMutex.Unlock()
-	return len(listeners)
+func listenerCount(s *Server, ws *WebSocket) int {
+	s.listenersMu.Lock()
+	defer s.listenersMu.Unlock()
+	return len(s.listeners[ws])
 }
 
-func hasListener(ws *WebSocket, id string) bool {
-	listenersMutex.Lock()
-	defer listenersMutex.Unlock()
-	if subs, ok := listeners[ws]; ok {
+func totalConnections(s *Server) int {
+	s.listenersMu.Lock()
+	defer s.listenersMu.Unlock()
+	return len(s.listeners)
+}
+
+func hasListener(s *Server, ws *WebSocket, id string) bool {
+	s.listenersMu.Lock()
+	defer s.listenersMu.Unlock()
+	if subs, ok := s.listeners[ws]; ok {
 		_, ok = subs[id]
 		return ok
 	}
@@ -29,150 +38,183 @@ func hasListener(ws *WebSocket, id string) bool {
 }
 
 func TestSetListener(t *testing.T) {
-	clearListeners()
-	defer clearListeners()
-
+	srv := newListenerTestServer()
 	ws := &WebSocket{}
-	setListener("sub1", ws, nostr.Filters{{Kinds: []int{1}}})
+	srv.setListener("sub1", ws, nostr.Filters{{Kinds: []int{1}}})
 
-	if !hasListener(ws, "sub1") {
+	if !hasListener(srv, ws, "sub1") {
 		t.Error("sub1 not found")
 	}
-	if listenerCount(ws) != 1 {
-		t.Errorf("expected 1 sub, got %d", listenerCount(ws))
+	if listenerCount(srv, ws) != 1 {
+		t.Errorf("expected 1 sub, got %d", listenerCount(srv, ws))
 	}
 }
 
 func TestSetListenerMultipleSubs(t *testing.T) {
-	clearListeners()
-	defer clearListeners()
-
+	srv := newListenerTestServer()
 	ws := &WebSocket{}
-	setListener("sub1", ws, nostr.Filters{{Kinds: []int{1}}})
-	setListener("sub2", ws, nostr.Filters{{Kinds: []int{2}}})
+	srv.setListener("sub1", ws, nostr.Filters{{Kinds: []int{1}}})
+	srv.setListener("sub2", ws, nostr.Filters{{Kinds: []int{2}}})
 
-	if listenerCount(ws) != 2 {
-		t.Errorf("expected 2 subs, got %d", listenerCount(ws))
+	if listenerCount(srv, ws) != 2 {
+		t.Errorf("expected 2 subs, got %d", listenerCount(srv, ws))
 	}
 }
 
 func TestSetListenerOverwrite(t *testing.T) {
-	clearListeners()
-	defer clearListeners()
-
+	srv := newListenerTestServer()
 	ws := &WebSocket{}
-	setListener("sub1", ws, nostr.Filters{{Kinds: []int{1}}})
-	setListener("sub1", ws, nostr.Filters{{Kinds: []int{2}}})
+	srv.setListener("sub1", ws, nostr.Filters{{Kinds: []int{1}}})
+	srv.setListener("sub1", ws, nostr.Filters{{Kinds: []int{2}}})
 
-	if listenerCount(ws) != 1 {
-		t.Errorf("expected 1 sub after overwrite, got %d", listenerCount(ws))
+	if listenerCount(srv, ws) != 1 {
+		t.Errorf("expected 1 sub after overwrite, got %d", listenerCount(srv, ws))
 	}
 }
 
 func TestSetListenerMultipleWS(t *testing.T) {
-	clearListeners()
-	defer clearListeners()
-
+	srv := newListenerTestServer()
 	ws1 := &WebSocket{}
 	ws2 := &WebSocket{}
-	setListener("sub1", ws1, nostr.Filters{{Kinds: []int{1}}})
-	setListener("sub1", ws2, nostr.Filters{{Kinds: []int{1}}})
+	srv.setListener("sub1", ws1, nostr.Filters{{Kinds: []int{1}}})
+	srv.setListener("sub1", ws2, nostr.Filters{{Kinds: []int{1}}})
 
-	if totalConnections() != 2 {
-		t.Errorf("expected 2 connections, got %d", totalConnections())
+	if totalConnections(srv) != 2 {
+		t.Errorf("expected 2 connections, got %d", totalConnections(srv))
 	}
 }
 
 func TestRemoveListenerId(t *testing.T) {
-	clearListeners()
-	defer clearListeners()
-
+	srv := newListenerTestServer()
 	ws := &WebSocket{}
-	setListener("sub1", ws, nostr.Filters{{Kinds: []int{1}}})
-	setListener("sub2", ws, nostr.Filters{{Kinds: []int{2}}})
+	srv.setListener("sub1", ws, nostr.Filters{{Kinds: []int{1}}})
+	srv.setListener("sub2", ws, nostr.Filters{{Kinds: []int{2}}})
 
-	removeListenerId(ws, "sub1")
+	srv.removeListenerId(ws, "sub1")
 
-	if hasListener(ws, "sub1") {
+	if hasListener(srv, ws, "sub1") {
 		t.Error("sub1 should be removed")
 	}
-	if !hasListener(ws, "sub2") {
+	if !hasListener(srv, ws, "sub2") {
 		t.Error("sub2 should still exist")
 	}
 }
 
 func TestRemoveListenerIdRemovesWSWhenEmpty(t *testing.T) {
-	clearListeners()
-	defer clearListeners()
-
+	srv := newListenerTestServer()
 	ws := &WebSocket{}
-	setListener("sub1", ws, nostr.Filters{{Kinds: []int{1}}})
+	srv.setListener("sub1", ws, nostr.Filters{{Kinds: []int{1}}})
 
-	removeListenerId(ws, "sub1")
+	srv.removeListenerId(ws, "sub1")
 
-	if totalConnections() != 0 {
+	if totalConnections(srv) != 0 {
 		t.Error("ws entry should be removed when all subs are gone")
 	}
 }
 
 func TestRemoveListenerIdNonexistent(t *testing.T) {
-	clearListeners()
-	defer clearListeners()
-
+	srv := newListenerTestServer()
 	ws := &WebSocket{}
-	// should not panic
-	removeListenerId(ws, "nope")
+	srv.removeListenerId(ws, "nope")
 }
 
 func TestRemoveListener(t *testing.T) {
-	clearListeners()
-	defer clearListeners()
-
+	srv := newListenerTestServer()
 	ws := &WebSocket{}
-	setListener("sub1", ws, nostr.Filters{{Kinds: []int{1}}})
-	setListener("sub2", ws, nostr.Filters{{Kinds: []int{2}}})
+	srv.setListener("sub1", ws, nostr.Filters{{Kinds: []int{1}}})
+	srv.setListener("sub2", ws, nostr.Filters{{Kinds: []int{2}}})
 
-	removeListener(ws)
+	srv.removeListener(ws)
 
-	if totalConnections() != 0 {
+	if totalConnections(srv) != 0 {
 		t.Error("ws should be removed")
 	}
 }
 
 func TestRemoveListenerNonexistent(t *testing.T) {
-	clearListeners()
-	defer clearListeners()
-
+	srv := newListenerTestServer()
 	ws := &WebSocket{}
-	// should not panic
-	removeListener(ws)
+	srv.removeListener(ws)
 }
 
 func TestGetListeningFilters(t *testing.T) {
-	clearListeners()
-	defer clearListeners()
-
+	srv := newListenerTestServer()
 	ws1 := &WebSocket{}
 	ws2 := &WebSocket{}
 
 	f1 := nostr.Filter{Kinds: []int{1}}
 	f2 := nostr.Filter{Kinds: []int{2}}
 
-	setListener("sub1", ws1, nostr.Filters{f1, f2})
-	setListener("sub2", ws2, nostr.Filters{f1}) // duplicate of f1
+	srv.setListener("sub1", ws1, nostr.Filters{f1, f2})
+	srv.setListener("sub2", ws2, nostr.Filters{f1})
 
-	filters := GetListeningFilters()
+	filters := srv.GetListeningFilters()
 	if len(filters) != 2 {
 		t.Errorf("expected 2 distinct filters, got %d", len(filters))
 	}
 }
 
 func TestGetListeningFiltersEmpty(t *testing.T) {
-	clearListeners()
-	defer clearListeners()
-
-	filters := GetListeningFilters()
+	srv := newListenerTestServer()
+	filters := srv.GetListeningFilters()
 	if len(filters) != 0 {
 		t.Errorf("expected 0 filters, got %d", len(filters))
 	}
+}
+
+func TestServersDoNotCrossDeliverSubscriptions(t *testing.T) {
+	srv1 := startTestRelay(t, &testRelay{storage: &slicestore.SliceStore{}})
+	defer srv1.Shutdown(context.TODO())
+	srv2 := startTestRelay(t, &testRelay{storage: &slicestore.SliceStore{}})
+	defer srv2.Shutdown(context.TODO())
+
+	pubConn := dialWS(t, srv1.Addr)
+	conn1 := dialWS(t, srv1.Addr)
+	conn2 := dialWS(t, srv2.Addr)
+
+	sendJSON(t, conn1, []interface{}{"REQ", "sub1", nostr.Filter{Kinds: []int{1}}})
+	if typ, _ := recvMessage(t, conn1); typ != "EOSE" {
+		t.Fatalf("expected EOSE, got %s", typ)
+	}
+
+	sendJSON(t, conn2, []interface{}{"REQ", "sub2", nostr.Filter{Kinds: []int{1}}})
+	if typ, _ := recvMessage(t, conn2); typ != "EOSE" {
+		t.Fatalf("expected EOSE, got %s", typ)
+	}
+
+	sk := nostr.GeneratePrivateKey()
+	evt := signedEvent(sk, 1, "server-1-only", nil)
+	sendJSON(t, pubConn, []interface{}{"EVENT", evt})
+	if _, ok, _ := recvOK(t, pubConn); !ok {
+		t.Fatal("expected publish to be accepted")
+	}
+
+	typ, raw := recvMessage(t, conn1)
+	if typ != "EVENT" {
+		t.Fatalf("expected EVENT on server 1, got %s", typ)
+	}
+	var subID string
+	if err := json.Unmarshal(raw[1], &subID); err != nil {
+		t.Fatalf("unmarshal sub id: %v", err)
+	}
+	if subID != "sub1" {
+		t.Fatalf("expected sub1, got %s", subID)
+	}
+
+	conn2.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+	if _, _, err := conn2.ReadMessage(); err == nil {
+		t.Fatal("unexpected cross-server event delivery")
+	} else if !websocket.IsCloseError(err) && !isTimeout(err) {
+		t.Fatalf("unexpected read error: %v", err)
+	}
+}
+
+func isTimeout(err error) bool {
+	type timeout interface {
+		Timeout() bool
+	}
+	if te, ok := err.(timeout); ok {
+		return te.Timeout()
+	}
+	return false
 }

--- a/start.go
+++ b/start.go
@@ -44,11 +44,19 @@ type Server struct {
 	clientsMu sync.Mutex
 	clients   map[*websocket.Conn]struct{}
 
+	listenersMu sync.RWMutex
+	listeners   map[*WebSocket]map[string]*Listener
+
 	// in case you call Server.Start
 	Addr       string
 	serveMux   *http.ServeMux
 	httpServer *http.Server
 }
+
+var (
+	servers      = map[*Server]struct{}{}
+	serversMutex sync.RWMutex
+)
 
 func (s *Server) Router() *http.ServeMux {
 	return s.serveMux
@@ -69,11 +77,12 @@ func NewServer(relay Relay, opts ...Option) (*Server, error) {
 	}
 
 	srv := &Server{
-		Log:      defaultLogger(relay.Name() + ": "),
-		relay:    relay,
-		clients:  make(map[*websocket.Conn]struct{}),
-		serveMux: &http.ServeMux{},
-		options:  options,
+		Log:       defaultLogger(relay.Name() + ": "),
+		relay:     relay,
+		clients:   make(map[*websocket.Conn]struct{}),
+		listeners: make(map[*WebSocket]map[string]*Listener),
+		serveMux:  &http.ServeMux{},
+		options:   options,
 	}
 
 	if storage := relay.Storage(context.Background()); storage != nil {
@@ -87,11 +96,15 @@ func NewServer(relay Relay, opts ...Option) (*Server, error) {
 		return nil, fmt.Errorf("relay init: %w", err)
 	}
 
+	serversMutex.Lock()
+	servers[srv] = struct{}{}
+	serversMutex.Unlock()
+
 	// start listening from events from other sources, if any
 	if inj, ok := relay.(Injector); ok {
 		go func() {
 			for event := range inj.InjectEvents() {
-				notifyListeners(&event)
+				srv.notifyListeners(&event)
 			}
 		}()
 	}
@@ -146,7 +159,9 @@ func (s *Server) Start(host string, port int, started ...chan bool) error {
 // Note that the HTTP server make some time to shutdown and so the context deadline,
 // if any, may have been shortened by the time OnShutdown is called.
 func (s *Server) Shutdown(ctx context.Context) {
-	s.httpServer.Shutdown(ctx)
+	if s.httpServer != nil {
+		s.httpServer.Shutdown(ctx)
+	}
 
 	s.clientsMu.Lock()
 	defer s.clientsMu.Unlock()
@@ -155,6 +170,10 @@ func (s *Server) Shutdown(ctx context.Context) {
 		conn.Close()
 		delete(s.clients, conn)
 	}
+
+	serversMutex.Lock()
+	delete(servers, s)
+	serversMutex.Unlock()
 
 	if f, ok := s.relay.(ShutdownAware); ok {
 		f.OnShutdown(ctx)

--- a/start_test.go
+++ b/start_test.go
@@ -69,6 +69,33 @@ func TestServerStartShutdown(t *testing.T) {
 	}
 }
 
+func TestNewServerInitFailureDoesNotRegisterServer(t *testing.T) {
+	relay := &testRelay{
+		init: func() error { return fmt.Errorf("boom") },
+		storage: &testStorage{
+			init: func() error { return nil },
+		},
+	}
+
+	serversMutex.RLock()
+	before := len(servers)
+	serversMutex.RUnlock()
+
+	srv, err := NewServer(relay)
+	if err == nil {
+		t.Fatal("expected init error")
+	}
+	if srv != nil {
+		t.Fatal("expected nil server on init failure")
+	}
+	serversMutex.RLock()
+	after := len(servers)
+	serversMutex.RUnlock()
+	if after != before {
+		t.Fatalf("expected servers registry size %d, got %d", before, after)
+	}
+}
+
 func TestServerShutdownWebsocket(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	// set up a new relay server

--- a/util_test.go
+++ b/util_test.go
@@ -107,9 +107,13 @@ func (st *testStorage) ReplaceEvent(ctx context.Context, e *nostr.Event) error {
 }
 
 func clearListeners() {
-	listenersMutex.Lock()
-	defer listenersMutex.Unlock()
-	listeners = make(map[*WebSocket]map[string]*Listener)
+	serversMutex.RLock()
+	defer serversMutex.RUnlock()
+	for srv := range servers {
+		srv.listenersMu.Lock()
+		srv.listeners = make(map[*WebSocket]map[string]*Listener)
+		srv.listenersMu.Unlock()
+	}
 }
 
 type testAdvancedStorage struct {


### PR DESCRIPTION
Move the global listeners map and mutex onto Server so each Server instance manages its own subscriptions, eliminating cross-server interference; GetListeningFilters and BroadcastEvent now iterate registered servers.

Benefits:
1. Servers no longer interfere with each other — multiple relays can coexist in one process without subscriptions leaking across them.
2. Lock contention is reduced — each Server has its own mutex, improving concurrency.
3. No state leaks — discarding a Server also discards its listeners.
4. Tests are independent — without global state, parallel and sequential tests don't interfere.