### PR TITLE
Fix examples to match current interfaces

### DIFF
--- a/examples/expensive/main.go
+++ b/examples/expensive/main.go
@@ -49,19 +49,19 @@ func (r *Relay) Init() error {
 	return nil
 }
 
-func (r *Relay) AcceptEvent(ctx context.Context, evt *nostr.Event) bool {
+func (r *Relay) AcceptEvent(ctx context.Context, evt *nostr.Event) (bool, string) {
 	// only accept they have a good preimage for a paid invoice for their public key
 	if !checkInvoicePaidOk(evt.PubKey) {
-		return false
+		return false, "invoice is not paid"
 	}
 
 	// block events that are too large
 	jsonb, _ := json.Marshal(evt)
 	if len(jsonb) > 100000 {
-		return false
+		return false, "event is too large"
 	}
 
-	return true
+	return true, ""
 }
 
 func main() {

--- a/examples/rss-bridge/handlers.go
+++ b/examples/rss-bridge/handlers.go
@@ -21,7 +21,14 @@ var head = H("head",
 
 func handleWebpage(w http.ResponseWriter, r *http.Request) {
 	items := make([]HTML, 0, 200)
-	iter := relay.db.NewIter(nil)
+	iter, err := relay.db.NewIter(nil)
+	if err != nil {
+		w.WriteHeader(500)
+		fmt.Fprint(w, "failed to create iterator: "+err.Error())
+		return
+	}
+	defer iter.Close()
+
 	for iter.First(); iter.Valid(); iter.Next() {
 		pubkey := string(iter.Key())
 		var entity Entity

--- a/examples/rss-bridge/main.go
+++ b/examples/rss-bridge/main.go
@@ -75,7 +75,7 @@ func (relay *Relay) Init() error {
 							if !ok || time.Unix(last.(int64), 0).Before(evt.CreatedAt.Time()) {
 								evt.Sign(entity.PrivateKey)
 								relay.updates <- evt
-								relay.lastEmitted.Store(entity.URL, last)
+								relay.lastEmitted.Store(entity.URL, evt.CreatedAt.Time().Unix())
 							}
 						}
 					}
@@ -87,8 +87,8 @@ func (relay *Relay) Init() error {
 	return nil
 }
 
-func (relay *Relay) AcceptEvent(ctx context.Context, _ *nostr.Event) bool {
-	return false
+func (relay *Relay) AcceptEvent(ctx context.Context, _ *nostr.Event) (bool, string) {
+	return false, "rss-bridge does not accept events"
 }
 
 func (relay *Relay) Storage(ctx context.Context) eventstore.Store {
@@ -105,6 +105,10 @@ func (b store) SaveEvent(ctx context.Context, _ *nostr.Event) error {
 	return errors.New("blocked: we don't accept any events")
 }
 
+func (b store) ReplaceEvent(ctx context.Context, _ *nostr.Event) error {
+	return errors.New("blocked: we don't accept any events")
+}
+
 func (b store) DeleteEvent(ctx context.Context, target *nostr.Event) error {
 	return errors.New("blocked: we can't delete any events")
 }
@@ -116,6 +120,8 @@ func (b store) QueryEvents(ctx context.Context, filter nostr.Filter) (chan *nost
 
 	evts := make(chan *nostr.Event)
 	go func() {
+		defer close(evts)
+
 		for _, pubkey := range filter.Authors {
 			if val, closer, err := relay.db.Get([]byte(pubkey)); err == nil {
 				defer closer.Close()
@@ -167,7 +173,7 @@ func (b store) QueryEvents(ctx context.Context, filter nostr.Filter) (chan *nost
 						evts <- &evt
 					}
 
-					relay.lastEmitted.Store(entity.URL, last)
+					relay.lastEmitted.Store(entity.URL, int64(last))
 				}
 			}
 		}

--- a/examples/search/main.go
+++ b/examples/search/main.go
@@ -33,14 +33,14 @@ func (r *Relay) Init() error {
 	return nil
 }
 
-func (r *Relay) AcceptEvent(ctx context.Context, evt *nostr.Event) bool {
+func (r *Relay) AcceptEvent(ctx context.Context, evt *nostr.Event) (bool, string) {
 	// block events that are too large
 	// jsonb, _ := json.Marshal(evt)
 	// if len(jsonb) > 100000 {
-	// 	return false
+	// 	return false, "event is too large"
 	// }
 
-	return true
+	return true, ""
 }
 
 func (r *Relay) BeforeSave(evt *nostr.Event) {

--- a/examples/whitelisted/main.go
+++ b/examples/whitelisted/main.go
@@ -31,7 +31,7 @@ func (r *Relay) Init() error {
 	return nil
 }
 
-func (r *Relay) AcceptEvent(ctx context.Context, evt *nostr.Event) bool {
+func (r *Relay) AcceptEvent(ctx context.Context, evt *nostr.Event) (bool, string) {
 	// disallow anything from non-authorized pubkeys
 	found := false
 	for _, pubkey := range r.Whitelist {
@@ -41,16 +41,16 @@ func (r *Relay) AcceptEvent(ctx context.Context, evt *nostr.Event) bool {
 		}
 	}
 	if !found {
-		return false
+		return false, "pubkey is not whitelisted"
 	}
 
 	// block events that are too large
 	jsonb, _ := json.Marshal(evt)
 	if len(jsonb) > 100000 {
-		return false
+		return false, "event is too large"
 	}
 
-	return true
+	return true, ""
 }
 
 func main() {


### PR DESCRIPTION
Update AcceptEvent signatures to (bool, string) across examples, handle pebble NewIter error return, add ReplaceEvent stub on the rss-bridge store, and fix the rss-bridge lastEmitted timestamp storage plus query channel close.