### PR TITLE
fix: issue NIP-42 challenge for protected subscriptions

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -213,6 +213,9 @@ func (s *Server) doReq(ctx context.Context, ws *WebSocket, request []json.RawMes
 
 	for _, filter := range filters {
 		if reason := s.validateFilterAccess(ws, filter, true); reason != "" {
+			if strings.HasPrefix(reason, "auth-required:") {
+				s.sendAuthChallenge(ws)
+			}
 			ws.WriteJSON(nostr.ClosedEnvelope{
 				SubscriptionID: id,
 				Reason:         reason,
@@ -327,9 +330,13 @@ func (s *Server) handleMessage(ctx context.Context, ws *WebSocket, message []byt
 
 	// NIP-42 auth challenge
 	if strings.HasPrefix(notice, "auth-required:") {
-		if _, ok := s.relay.(Auther); ok {
-			ws.WriteJSON(nostr.AuthEnvelope{Challenge: &ws.challenge})
-		}
+		s.sendAuthChallenge(ws)
+	}
+}
+
+func (s *Server) sendAuthChallenge(ws *WebSocket) {
+	if _, ok := s.relay.(Auther); ok {
+		ws.WriteJSON(nostr.AuthEnvelope{Challenge: &ws.challenge})
 	}
 }
 
@@ -343,7 +350,7 @@ func (s *Server) validateFilterAccess(ws *WebSocket, filter nostr.Filter, allowG
 		receivers, _ := filter.Tags["p"]
 		switch {
 		case ws.authed == "":
-			return "restricted: this relay does not serve kind-4 to unauthenticated users, does your client implement NIP-42?"
+			return "auth-required: this relay requires NIP-42 authentication to serve kind-4 events"
 		case len(senders) == 1 && len(receivers) < 2 && senders[0] == ws.authed:
 		case len(receivers) == 1 && len(senders) < 2 && receivers[0] == ws.authed:
 		default:
@@ -355,7 +362,7 @@ func (s *Server) validateFilterAccess(ws *WebSocket, filter nostr.Filter, allowG
 		receivers, _ := filter.Tags["p"]
 		switch {
 		case ws.authed == "":
-			return "restricted: this relay does not serve gift-wrapped events to unauthenticated users, does your client implement NIP-42?"
+			return "auth-required: this relay requires NIP-42 authentication to serve gift-wrapped events"
 		case len(receivers) == 1 && receivers[0] == ws.authed:
 		default:
 			return "restricted: authenticated user does not have authorization for requested filters."

--- a/nip59_test.go
+++ b/nip59_test.go
@@ -72,7 +72,6 @@ func readMsg(t *testing.T, conn *websocket.Conn) (string, []json.RawMessage) {
 // authenticate performs NIP-42 auth via the GETCHALLENGE custom message.
 func authenticate(t *testing.T, conn *websocket.Conn, sk string, relayURL string) string {
 	t.Helper()
-	pub, _ := nostr.GetPublicKey(sk)
 
 	// get challenge from server
 	conn.WriteJSON([]interface{}{"GETCHALLENGE", ""})
@@ -82,6 +81,12 @@ func authenticate(t *testing.T, conn *websocket.Conn, sk string, relayURL string
 	}
 	var challenge string
 	json.Unmarshal(raw[1], &challenge)
+	return authenticateWithChallenge(t, conn, sk, relayURL, challenge)
+}
+
+func authenticateWithChallenge(t *testing.T, conn *websocket.Conn, sk string, relayURL, challenge string) string {
+	t.Helper()
+	pub, _ := nostr.GetPublicKey(sk)
 
 	// create and sign auth event
 	authEvt := nip42.CreateUnsignedAuthEvent(challenge, pub, relayURL)
@@ -89,7 +94,7 @@ func authenticate(t *testing.T, conn *websocket.Conn, sk string, relayURL string
 
 	// send AUTH
 	conn.WriteJSON([]interface{}{"AUTH", authEvt})
-	typ, raw = readMsg(t, conn)
+	typ, raw := readMsg(t, conn)
 	if typ != "OK" {
 		t.Fatalf("expected OK, got %s", typ)
 	}
@@ -116,13 +121,37 @@ func TestNIP59_GiftWrap_Unauthenticated(t *testing.T) {
 	conn.WriteJSON([]interface{}{"REQ", "sub1", nostr.Filter{Kinds: []int{nostr.KindGiftWrap}}})
 
 	typ, raw := readMsg(t, conn)
+	if typ != "AUTH" {
+		t.Fatalf("expected AUTH challenge, got %s", typ)
+	}
+	var challenge string
+	json.Unmarshal(raw[1], &challenge)
+	if challenge == "" {
+		t.Fatal("expected non-empty AUTH challenge")
+	}
+
+	typ, raw = readMsg(t, conn)
 	if typ != "CLOSED" {
 		t.Fatalf("expected CLOSED, got %s", typ)
 	}
 	var reason string
 	json.Unmarshal(raw[2], &reason)
-	if reason != "restricted: this relay does not serve gift-wrapped events to unauthenticated users, does your client implement NIP-42?" {
+	if reason != "auth-required: this relay requires NIP-42 authentication to serve gift-wrapped events" {
 		t.Errorf("unexpected reason: %q", reason)
+	}
+
+	// Authenticate using the relay-provided challenge and retry a
+	// recipient-scoped subscription, as a NIP-42 client would.
+	sk := nostr.GeneratePrivateKey()
+	pub := authenticateWithChallenge(t, conn, sk, "ws://"+srv.Addr, challenge)
+	conn.WriteJSON([]interface{}{"REQ", "sub2", nostr.Filter{
+		Kinds: []int{nostr.KindGiftWrap},
+		Tags:  nostr.TagMap{"p": []string{pub}},
+	}})
+
+	typ, _ = readMsg(t, conn)
+	if typ != "EOSE" {
+		t.Fatalf("expected EOSE after authentication, got %s", typ)
 	}
 }
 


### PR DESCRIPTION
## Summary

- return the NIP-42 auth-required prefix when unauthenticated clients request protected kind-4 or kind-1059 events
- emit the per-connection AUTH challenge before closing the subscription
- keep authenticated recipient authorization unchanged
- cover the complete gift-wrap flow from challenge through signed AUTH and successful retry

This fixes the delivery failure investigated in hedwig-corp/bitchat-to-sonar#243. Clients could not authenticate because REQ returned restricted without ever sending the challenge required to construct a kind-22242 event.

Spec: https://github.com/nostr-protocol/nips/blob/master/42.md

## Verification

- GOPATH=/tmp/relayer-gopath GOCACHE=/tmp/relayer-go-cache go test ./... -count=1 -timeout=120s