### PR TITLE
Fix release workflow by updating go-release-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,13 +31,13 @@ jobs:
           - goarch: arm64
             goos: windows
     steps:
-      - uses: actions/checkout@v3
-      - uses: wangyoucao577/go-release-action@v1.30
+      - uses: actions/checkout@v4
+      - uses: wangyoucao577/go-release-action@v1.55
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
-          goversion: "1.21"
+          goversion: "go.mod"
           project_path: ${{ matrix.project }}
           binary_name: "relayer-${{ matrix.project }}-${{ matrix.goos }}-${{ matrix.goarch }}"
           overwrite: true


### PR DESCRIPTION
The tagged release builds (v2.2.11, v2.2.12) have been failing before even compiling anything: go-release-action v1.30's `setup-go.sh` fetches `https://go.dev/VERSION?m=text`, which now returns two lines (`go1.26.5` + a `time ...` line). The old script interpolates both lines into the download URL, producing a broken `wget` invocation:

```
wget https://go.dev/dl/go1.26.5 time 2026-07-01T21:24:27Z.linux-amd64.tar.gz
Resolving time (time)... failed: Name or service not known.
```

Changes:

- Bump `wangyoucao577/go-release-action` v1.30 → v1.55, which handles the multi-line VERSION response (`head -n1`).
- Change `goversion` from `"1.21"` to `"go.mod"` — the workflow pinned Go 1.21 while go.mod requires 1.23.1, so builds would have failed at the next step anyway. v1.55 reads the version straight from go.mod, so future toolchain bumps won't need a workflow edit.
- Bump `actions/checkout` v3 → v4.

After merging, re-running the failed v2.2.12 workflow run should upload the release assets (the release already exists and the action uses `overwrite: true`).