### PR TITLE
Fix release workflow project paths after examples move

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,6 @@ jobs:
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
           goversion: "go.mod"
-          project_path: ${{ matrix.project }}
+          project_path: examples/${{ matrix.project }}
           binary_name: "relayer-${{ matrix.project }}-${{ matrix.goos }}-${{ matrix.goarch }}"
           overwrite: true


### PR DESCRIPTION
Follow-up to #152. The v2.2.13 release build got past the Go setup but failed with:

```
no Go files in /github/workspace/expensive
```

The example relays now live under `examples/`, but the release workflow's `project_path` still pointed at the repository root. This prefixes the path with `examples/`; binary names are unchanged.

All five examples cross-compile locally with the root go.mod (verified linux/amd64 for each, plus an openbsd/arm64 spot check).