### PR TITLE
handlers: log ping-write failures at info, not error

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -471,7 +471,9 @@ func (s *Server) HandleWebsocket(w http.ResponseWriter, r *http.Request) {
 			case <-ticker.C:
 				err := conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(writeWait))
 				if err != nil {
-					s.Log.Errorf("error writing ping: %v; closing websocket", err)
+					// a client that goes away between keepalives is ordinary churn
+					// on a public relay, not a fault: log it at info, not error.
+					s.Log.Infof("ping failed for %s, closing websocket: %v", ip, err)
 					return
 				}
 				s.Log.Infof("pinging for %s", ip)


### PR DESCRIPTION
A client disappearing between two keepalives is ordinary churn on a public relay, not a fault, but the ping-write failure was logged via `Log.Errorf`. On a busy relay these disconnects dominate the error stream — ~94% of all ERROR lines in one operator's 48h window. Log it at `Infof` instead, matching the adjacent `pinging for %s` line, so genuine faults stay visible at the error level.

(The `Logger` interface has no `Debugf`, so info is the quietest level available in-framework; happy to drop the line entirely instead if you'd prefer.)
