### PR TITLE
Count NIP-45 filters as a union when the store can

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -155,24 +155,38 @@ func (s *Server) doCount(ctx context.Context, ws *WebSocket, request []json.RawM
 		return "COUNT has no <id>"
 	}
 
-	total := int64(0)
 	filters := make(nostr.Filters, len(request)-2)
 	for i, filterReq := range request[2:] {
 		if err := json.Unmarshal(filterReq, &filters[i]); err != nil {
 			return "failed to decode filter"
 		}
 
-		filter := filters[i]
-		if reason := s.validateFilterAccess(ws, filter, false); reason != "" {
+		if reason := s.validateFilterAccess(ws, filters[i], false); reason != "" {
 			return reason
 		}
+	}
 
-		count, err := counter.CountEvents(ctx, filter)
+	total := int64(0)
+	// NIP-45 OR's the filters together into a single count, so an event
+	// matching more than one of them counts once. Only a store that can
+	// evaluate the union knows which events those are; without one the counts
+	// are summed, which is exact for filters that do not overlap.
+	if union, ok := store.(FiltersCounter); ok && len(filters) > 1 {
+		count, err := union.CountEventsFilters(ctx, filters)
 		if err != nil {
 			s.Log.Errorf("store: %v", err)
-			continue
+			return "error: failed to count events"
 		}
-		total += count
+		total = count
+	} else {
+		for _, filter := range filters {
+			count, err := counter.CountEvents(ctx, filter)
+			if err != nil {
+				s.Log.Errorf("store: %v", err)
+				continue
+			}
+			total += count
+		}
 	}
 
 	ws.WriteJSON([]interface{}{"COUNT", id, map[string]int64{"count": total}})

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -524,9 +524,139 @@ type testStorageWithCounter struct {
 	countEvents func(context.Context, nostr.Filter) (int64, error)
 }
 
+type testStorageWithFiltersCounter struct {
+	testStorageWithCounter
+	countEventsFilters func(context.Context, nostr.Filters) (int64, error)
+}
+
+func (s *testStorageWithFiltersCounter) CountEventsFilters(ctx context.Context, f nostr.Filters) (int64, error) {
+	if s.countEventsFilters != nil {
+		return s.countEventsFilters(ctx, f)
+	}
+	return 0, nil
+}
+
 func (s *testStorageWithCounter) CountEvents(ctx context.Context, f nostr.Filter) (int64, error) {
 	if s.countEvents != nil {
 		return s.countEvents(ctx, f)
 	}
 	return 0, nil
+}
+
+func TestDoCount_SumsFiltersWithoutAUnionCounter(t *testing.T) {
+	// A store that can only count one filter at a time is still summed: that
+	// is exact as long as the filters do not overlap.
+	calls := 0
+	st := &testStorageWithCounter{
+		testStorage: testStorage{},
+		countEvents: func(_ context.Context, _ nostr.Filter) (int64, error) {
+			calls++
+			return 3, nil
+		},
+	}
+	srv := startTestRelay(t, &testRelay{storage: st})
+	defer srv.Shutdown(context.TODO())
+
+	conn := dialWS(t, srv.Addr)
+	sendJSON(t, conn, []interface{}{"COUNT", "c1",
+		nostr.Filter{Kinds: []int{1}}, nostr.Filter{Kinds: []int{7}}})
+
+	typ, raw := recvMessage(t, conn)
+	if typ != "COUNT" {
+		t.Fatalf("expected COUNT, got %s", typ)
+	}
+	var res struct {
+		Count int64 `json:"count"`
+	}
+	json.Unmarshal(raw[2], &res)
+	if res.Count != 6 {
+		t.Errorf("count = %d, want 6", res.Count)
+	}
+	if calls != 2 {
+		t.Errorf("CountEvents called %d times, want 2", calls)
+	}
+}
+
+func TestDoCount_UnionCounterSeesEveryFilter(t *testing.T) {
+	// NIP-45 OR's the filters together, so an event matching more than one of
+	// them counts once. A store that can evaluate the union is handed all the
+	// filters at once instead of being asked about them one by one.
+	var got nostr.Filters
+	perFilterCalls := 0
+	st := &testStorageWithFiltersCounter{
+		testStorageWithCounter: testStorageWithCounter{
+			testStorage: testStorage{},
+			countEvents: func(_ context.Context, _ nostr.Filter) (int64, error) {
+				perFilterCalls++
+				return 3, nil
+			},
+		},
+		countEventsFilters: func(_ context.Context, f nostr.Filters) (int64, error) {
+			got = f
+			return 4, nil
+		},
+	}
+	srv := startTestRelay(t, &testRelay{storage: st})
+	defer srv.Shutdown(context.TODO())
+
+	conn := dialWS(t, srv.Addr)
+	sendJSON(t, conn, []interface{}{"COUNT", "c1",
+		nostr.Filter{Kinds: []int{1}}, nostr.Filter{Kinds: []int{1, 7}}})
+
+	typ, raw := recvMessage(t, conn)
+	if typ != "COUNT" {
+		t.Fatalf("expected COUNT, got %s", typ)
+	}
+	var res struct {
+		Count int64 `json:"count"`
+	}
+	json.Unmarshal(raw[2], &res)
+	if res.Count != 4 {
+		t.Errorf("count = %d, want 4 (the union, not the sum)", res.Count)
+	}
+	if len(got) != 2 {
+		t.Fatalf("union counter saw %d filters, want 2", len(got))
+	}
+	if perFilterCalls != 0 {
+		t.Errorf("CountEvents called %d times, want 0", perFilterCalls)
+	}
+}
+
+func TestDoCount_SingleFilterUsesCountEvents(t *testing.T) {
+	// One filter cannot overlap with itself, so the union path is unnecessary.
+	unionCalls := 0
+	perFilterCalls := 0
+	st := &testStorageWithFiltersCounter{
+		testStorageWithCounter: testStorageWithCounter{
+			testStorage: testStorage{},
+			countEvents: func(_ context.Context, _ nostr.Filter) (int64, error) {
+				perFilterCalls++
+				return 5, nil
+			},
+		},
+		countEventsFilters: func(_ context.Context, _ nostr.Filters) (int64, error) {
+			unionCalls++
+			return 99, nil
+		},
+	}
+	srv := startTestRelay(t, &testRelay{storage: st})
+	defer srv.Shutdown(context.TODO())
+
+	conn := dialWS(t, srv.Addr)
+	sendJSON(t, conn, []interface{}{"COUNT", "c1", nostr.Filter{Kinds: []int{1}}})
+
+	typ, raw := recvMessage(t, conn)
+	if typ != "COUNT" {
+		t.Fatalf("expected COUNT, got %s", typ)
+	}
+	var res struct {
+		Count int64 `json:"count"`
+	}
+	json.Unmarshal(raw[2], &res)
+	if res.Count != 5 {
+		t.Errorf("count = %d, want 5", res.Count)
+	}
+	if unionCalls != 0 || perFilterCalls != 1 {
+		t.Errorf("union=%d perFilter=%d, want 0 and 1", unionCalls, perFilterCalls)
+	}
 }

--- a/interface.go
+++ b/interface.go
@@ -87,3 +87,14 @@ type AdvancedSaver interface {
 type EventCounter interface {
 	CountEvents(ctx context.Context, filter nostr.Filter) (int64, error)
 }
+
+// FiltersCounter counts the events matching any of several filters for NIP-45,
+// which asks for the filters to be OR'd together into a single count. Summing
+// CountEvents over each filter separately counts an event that matches more
+// than one of them once per filter, so a store that can evaluate the union
+// itself — a SQL backend counting over a UNION, say — should implement this.
+// Stores that do not are still summed, which is exact as long as the filters
+// do not overlap.
+type FiltersCounter interface {
+	CountEventsFilters(ctx context.Context, filters nostr.Filters) (int64, error)
+}


### PR DESCRIPTION
[NIP-45](https://github.com/nostr-protocol/nips/blob/master/45.md) says:

> This NIP defines the verb `COUNT`, which accepts a query id and filters as specified in [NIP 01](01.md) for the verb `REQ`. Multiple filters are OR'd together and aggregated into a single count result.

OR'd together is a union, so an event matching more than one filter belongs to it once. `doCount` sums `CountEvents` over each filter, which counts that event once per filter it matches. The sum is exact when the filters do not overlap and too high when they do — the same filter sent twice returns twice the number of events that exist.

Against a relay holding 833,674 kind-1 and 704,880 kind-7 events:

```
["COUNT","c1",{"kinds":[1]}]                     ->   833,674
["COUNT","c1",{"kinds":[1]},{"kinds":[1]}]       -> 1,667,348
["COUNT","c1",{"kinds":[1]},{"kinds":[1,7]}]     -> 2,372,228   (the union is 1,538,554)
```

Only a store that can evaluate the union knows which events those are, and collecting the ids here to deduplicate them would cost one id per stored event. So this adds an optional `FiltersCounter` interface and uses it when the store implements it and there is more than one filter. Stores that do not implement it are still summed, so nothing changes for them.

fiatjaf/eventstore#74 implements it for the SQL backends.
