### PR TITLE
Fix listener retention after WebSocket disconnect

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -430,9 +430,9 @@ func (s *Server) HandleWebsocket(w http.ResponseWriter, r *http.Request) {
 			if _, ok := s.clients[conn]; ok {
 				conn.Close()
 				delete(s.clients, conn)
-				s.removeListener(ws)
 			}
 			s.clientsMu.Unlock()
+			s.removeListener(ws)
 			s.Log.Infof("disconnected from %s", ip)
 		}()
 

--- a/listener.go
+++ b/listener.go
@@ -51,6 +51,9 @@ func appendDistinctFilters(dst nostr.Filters, src nostr.Filters) nostr.Filters {
 func (s *Server) setListener(id string, ws *WebSocket, filters nostr.Filters) {
 	s.listenersMu.Lock()
 	defer s.listenersMu.Unlock()
+	if ws.disconnected {
+		return
+	}
 
 	subs, ok := s.listeners[ws]
 	if !ok {
@@ -78,6 +81,7 @@ func (s *Server) removeListenerId(ws *WebSocket, id string) {
 func (s *Server) removeListener(ws *WebSocket) {
 	s.listenersMu.Lock()
 	defer s.listenersMu.Unlock()
+	ws.disconnected = true
 	clear(s.listeners[ws])
 	delete(s.listeners, ws)
 }

--- a/listener_test.go
+++ b/listener_test.go
@@ -3,6 +3,7 @@ package relayer
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"testing"
 	"time"
 
@@ -135,6 +136,43 @@ func TestRemoveListenerNonexistent(t *testing.T) {
 	srv := newListenerTestServer()
 	ws := &WebSocket{}
 	srv.removeListener(ws)
+}
+
+func TestLateRequestCannotRetainDisconnectedClient(t *testing.T) {
+	for _, hadSubscription := range []bool{false, true} {
+		srv := newListenerTestServer()
+		ws := &WebSocket{}
+		if hadSubscription {
+			srv.setListener("existing", ws, nostr.Filters{{Kinds: []int{1}}})
+		}
+		// A history query may finish after the reader's disconnect cleanup.
+		srv.removeListener(ws)
+		srv.setListener("late", ws, nostr.Filters{{Authors: []string{"retained-author"}}})
+		if totalConnections(srv) != 0 {
+			t.Errorf("late REQ retained disconnected client (existing subscription: %v)", hadSubscription)
+		}
+	}
+}
+
+func TestDisconnectRacingWithListenerRegistration(t *testing.T) {
+	srv := newListenerTestServer()
+	for range 1000 {
+		ws := &WebSocket{}
+		var workers sync.WaitGroup
+		workers.Add(2)
+		go func() {
+			defer workers.Done()
+			srv.setListener("late", ws, nostr.Filters{{Kinds: []int{1}}})
+		}()
+		go func() {
+			defer workers.Done()
+			srv.removeListener(ws)
+		}()
+		workers.Wait()
+	}
+	if n := totalConnections(srv); n != 0 {
+		t.Fatalf("retained %d disconnected clients", n)
+	}
 }
 
 func TestGetListeningFilters(t *testing.T) {

--- a/websocket.go
+++ b/websocket.go
@@ -11,6 +11,9 @@ type WebSocket struct {
 	conn  *websocket.Conn
 	mutex sync.Mutex
 
+	// Protected by Server.listenersMu. Disconnect permanently forbids new listeners.
+	disconnected bool
+
 	// nip42
 	challenge string
 	authed    string


### PR DESCRIPTION
A history query finishing after WebSocket cleanup could register a listener again, retaining the disconnected client and its filters indefinitely. Mark disconnected clients under the listener lock, reject late registrations, and always clean up listeners when the reader exits, including during shutdown.

Verified the regression fails before the fix; local tests and focused race tests pass, including 1,000 concurrent registration/disconnect cycles.
