### PR TITLE
Prevent pending REQs from restoring closed or replaced subscriptions

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -193,11 +193,15 @@ func (s *Server) doCount(ctx context.Context, ws *WebSocket, request []json.RawM
 	return ""
 }
 
-func (s *Server) doReq(ctx context.Context, ws *WebSocket, request []json.RawMessage, store eventstore.Store) string {
+func (s *Server) doReq(ctx context.Context, ws *WebSocket, request []json.RawMessage, store eventstore.Store, req *subscriptionRequest) string {
 	var id string
 	json.Unmarshal(request[1], &id)
 	if id == "" {
 		return "REQ has no <id>"
+	}
+	defer s.finishRequest(ws, id, req)
+	if ctx.Err() != nil {
+		return ""
 	}
 
 	filters := make(nostr.Filters, len(request)-2)
@@ -215,7 +219,11 @@ func (s *Server) doReq(ctx context.Context, ws *WebSocket, request []json.RawMes
 	}
 
 	if accepter, ok := s.relay.(ReqAccepter); ok {
-		if !accepter.AcceptReq(ctx, id, filters, ws.authed) {
+		accepted := accepter.AcceptReq(ctx, id, filters, ws.authed)
+		if ctx.Err() != nil {
+			return ""
+		}
+		if !accepted {
 			ws.WriteJSON(nostr.EOSEEnvelope(id))
 			ws.WriteJSON(nostr.ClosedEnvelope{
 				SubscriptionID: id,
@@ -226,6 +234,9 @@ func (s *Server) doReq(ctx context.Context, ws *WebSocket, request []json.RawMes
 	}
 
 	for _, filter := range filters {
+		if ctx.Err() != nil {
+			return ""
+		}
 		if reason := s.validateFilterAccess(ws, filter, true); reason != "" {
 			if strings.HasPrefix(reason, "auth-required:") {
 				s.sendAuthChallenge(ws)
@@ -242,6 +253,9 @@ func (s *Server) doReq(ctx context.Context, ws *WebSocket, request []json.RawMes
 
 		events, err := store.QueryEvents(ctx, filter)
 		if err != nil {
+			if ctx.Err() != nil {
+				return ""
+			}
 			s.Log.Errorf("store: %v", err)
 			continue
 		}
@@ -252,25 +266,44 @@ func (s *Server) doReq(ctx context.Context, ws *WebSocket, request []json.RawMes
 		}
 		i := 0
 		if events != nil {
-			for event := range events {
+		readEvents:
+			for {
+				var event *nostr.Event
+				select {
+				case <-ctx.Done():
+					return ""
+				case next, ok := <-events:
+					if !ok {
+						break readEvents
+					}
+					event = next
+				}
+				if ctx.Err() != nil {
+					return ""
+				}
+				// Keep draining after the limit, in case storage returns extra
+				// events, but let cancellation stop an unfinished stream.
+				if i >= filter.Limit {
+					continue
+				}
 				if s.options.skipEventFunc != nil && s.options.skipEventFunc(event) {
 					continue
 				}
-				ws.WriteJSON(nostr.EventEnvelope{SubscriptionID: &id, Event: *event})
-				i++
-				if i >= filter.Limit {
-					break
+				if err := ws.WriteJSON(nostr.EventEnvelope{SubscriptionID: &id, Event: *event}); err != nil {
+					return ""
 				}
-			}
-
-			// exhaust the channel (in case we broke out of it early) so it is closed by the storage
-			for range events {
+				i++
 			}
 		}
 	}
 
-	ws.WriteJSON(nostr.EOSEEnvelope(id))
-	s.setListener(id, ws, filters)
+	if ctx.Err() != nil {
+		return ""
+	}
+	if err := ws.WriteJSON(nostr.EOSEEnvelope(id)); err != nil {
+		return ""
+	}
+	s.registerRequest(ws, id, req, filters)
 	return ""
 }
 
@@ -302,13 +335,6 @@ func (s *Server) doAuth(ctx context.Context, ws *WebSocket, request []json.RawMe
 }
 
 func (s *Server) handleMessage(ctx context.Context, ws *WebSocket, message []byte, store eventstore.Store) {
-	var notice string
-	defer func() {
-		if notice != "" {
-			ws.WriteJSON(nostr.NoticeEnvelope(notice))
-		}
-	}()
-
 	var request []json.RawMessage
 	if err := json.Unmarshal(message, &request); err != nil {
 		// stop silently
@@ -316,7 +342,7 @@ func (s *Server) handleMessage(ctx context.Context, ws *WebSocket, message []byt
 	}
 
 	if len(request) < 2 {
-		notice = "request has less than 2 parameters"
+		ws.WriteJSON(nostr.NoticeEnvelope("request has less than 2 parameters"))
 		return
 	}
 
@@ -326,15 +352,41 @@ func (s *Server) handleMessage(ctx context.Context, ws *WebSocket, message []byt
 	ctx = context.WithValue(ctx, AUTH_CONTEXT_KEY, ws)
 	ctx = context.WithValue(ctx, SERVER_CONTEXT_KEY, s)
 
+	// Reserve REQ tokens and process CLOSE in reader order, before starting
+	// workers. Ordering only inside doReq would still let a delayed worker
+	// start after its CLOSE or after a newer REQ with the same ID.
+	var req *subscriptionRequest
+	if typ == "REQ" {
+		var id string
+		json.Unmarshal(request[1], &id)
+		if id != "" {
+			req = s.beginRequest(ctx, ws, id)
+			ctx = req.ctx
+		}
+	} else if typ == "CLOSE" {
+		if notice := s.doClose(ctx, ws, request, store); notice != "" {
+			ws.WriteJSON(nostr.NoticeEnvelope(notice))
+		}
+		return
+	}
+	go s.handleParsedMessage(ctx, ws, request, store, typ, req)
+}
+
+func (s *Server) handleParsedMessage(ctx context.Context, ws *WebSocket, request []json.RawMessage, store eventstore.Store, typ string, req *subscriptionRequest) {
+	var notice string
+	defer func() {
+		if notice != "" {
+			ws.WriteJSON(nostr.NoticeEnvelope(notice))
+		}
+	}()
+
 	switch typ {
 	case "EVENT":
 		notice = s.doEvent(ctx, ws, request, store)
 	case "COUNT":
 		notice = s.doCount(ctx, ws, request, store)
 	case "REQ":
-		notice = s.doReq(ctx, ws, request, store)
-	case "CLOSE":
-		notice = s.doClose(ctx, ws, request, store)
+		notice = s.doReq(ctx, ws, request, store, req)
 	case "AUTH":
 		notice = s.doAuth(ctx, ws, request, store)
 	default:
@@ -471,7 +523,7 @@ func (s *Server) HandleWebsocket(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 
-			go s.handleMessage(ctx, ws, message, store)
+			s.handleMessage(ctx, ws, message, store)
 		}
 	}()
 

--- a/listener.go
+++ b/listener.go
@@ -1,6 +1,59 @@
 package relayer
 
-import "github.com/nbd-wtf/go-nostr"
+import (
+	"context"
+
+	"github.com/nbd-wtf/go-nostr"
+)
+
+// Only in-flight requests are tracked. Removing an entry invalidates its
+// registration token, without retaining a tombstone for every closed ID.
+type subscriptionRequest struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func (s *Server) beginRequest(ctx context.Context, ws *WebSocket, id string) *subscriptionRequest {
+	s.listenersMu.Lock()
+	defer s.listenersMu.Unlock()
+	ctx, cancel := context.WithCancel(ctx)
+	req := &subscriptionRequest{ctx: ctx, cancel: cancel}
+	if ws.disconnected {
+		cancel()
+		return req
+	}
+	if old := ws.requests[id]; old != nil {
+		old.cancel()
+	}
+	if ws.requests == nil {
+		ws.requests = make(map[string]*subscriptionRequest)
+	}
+	ws.requests[id] = req
+	// A replacement stops the old live subscription immediately as well.
+	s.removeListenerIdLocked(ws, id)
+	return req
+}
+
+func (s *Server) finishRequest(ws *WebSocket, id string, req *subscriptionRequest) {
+	s.listenersMu.Lock()
+	defer s.listenersMu.Unlock()
+	if ws.requests[id] == req {
+		delete(ws.requests, id)
+		if len(ws.requests) == 0 {
+			ws.requests = nil
+		}
+	}
+	req.cancel()
+}
+
+func (s *Server) registerRequest(ws *WebSocket, id string, req *subscriptionRequest, filters nostr.Filters) {
+	s.listenersMu.Lock()
+	defer s.listenersMu.Unlock()
+	if ws.requests[id] != req || req.ctx.Err() != nil {
+		return
+	}
+	s.setListenerLocked(id, ws, filters)
+}
 
 type Listener struct {
 	filters nostr.Filters
@@ -51,6 +104,10 @@ func appendDistinctFilters(dst nostr.Filters, src nostr.Filters) nostr.Filters {
 func (s *Server) setListener(id string, ws *WebSocket, filters nostr.Filters) {
 	s.listenersMu.Lock()
 	defer s.listenersMu.Unlock()
+	s.setListenerLocked(id, ws, filters)
+}
+
+func (s *Server) setListenerLocked(id string, ws *WebSocket, filters nostr.Filters) {
 	if ws.disconnected {
 		return
 	}
@@ -68,7 +125,17 @@ func (s *Server) setListener(id string, ws *WebSocket, filters nostr.Filters) {
 func (s *Server) removeListenerId(ws *WebSocket, id string) {
 	s.listenersMu.Lock()
 	defer s.listenersMu.Unlock()
+	if req := ws.requests[id]; req != nil {
+		req.cancel()
+		delete(ws.requests, id)
+		if len(ws.requests) == 0 {
+			ws.requests = nil
+		}
+	}
+	s.removeListenerIdLocked(ws, id)
+}
 
+func (s *Server) removeListenerIdLocked(ws *WebSocket, id string) {
 	if subs, ok := s.listeners[ws]; ok {
 		delete(s.listeners[ws], id)
 		if len(subs) == 0 {
@@ -82,6 +149,10 @@ func (s *Server) removeListener(ws *WebSocket) {
 	s.listenersMu.Lock()
 	defer s.listenersMu.Unlock()
 	ws.disconnected = true
+	for _, req := range ws.requests {
+		req.cancel()
+	}
+	ws.requests = nil
 	clear(s.listeners[ws])
 	delete(s.listeners, ws)
 }

--- a/request_lifecycle_test.go
+++ b/request_lifecycle_test.go
@@ -1,0 +1,202 @@
+package relayer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/nbd-wtf/go-nostr"
+)
+
+func TestCloseCancelsPendingHistory(t *testing.T) {
+	testPendingHistoryCancellation(t, "CLOSE")
+}
+
+func TestLateHistoryCannotRestoreClosedOrReplacedListener(t *testing.T) {
+	for _, operation := range []string{"close", "replace", "disconnect"} {
+		t.Run(operation, func(t *testing.T) {
+			srv := newListenerTestServer()
+			ws := &WebSocket{}
+			old := srv.beginRequest(context.Background(), ws, "sub")
+			var replacement *subscriptionRequest
+			switch operation {
+			case "close":
+				srv.removeListenerId(ws, "sub")
+			case "replace":
+				replacement = srv.beginRequest(context.Background(), ws, "sub")
+				srv.registerRequest(ws, "sub", replacement, nostr.Filters{{Kinds: []int{2}}})
+			case "disconnect":
+				srv.removeListener(ws)
+			}
+			// Even a backend that ignores cancellation cannot commit old filters.
+			srv.registerRequest(ws, "sub", old, nostr.Filters{{Kinds: []int{1}}})
+			srv.finishRequest(ws, "sub", old)
+			if operation == "replace" {
+				if ws.requests["sub"] != replacement {
+					t.Fatal("old worker removed the replacement's request state")
+				}
+				filters := srv.GetListeningFilters()
+				if len(filters) != 1 || len(filters[0].Kinds) != 1 || filters[0].Kinds[0] != 2 {
+					t.Fatalf("old request overwrote replacement: %v", filters)
+				}
+				srv.finishRequest(ws, "sub", replacement)
+			} else if totalConnections(srv) != 0 {
+				t.Fatal("late history restored a removed listener")
+			}
+			if len(ws.requests) != 0 {
+				t.Fatal("finished requests retained bookkeeping")
+			}
+		})
+	}
+}
+
+func TestRequestCancellationStopsUnfinishedStream(t *testing.T) {
+	for _, limit := range []int{1, 2} {
+		t.Run(fmt.Sprintf("limit=%d", limit), func(t *testing.T) {
+			// The real connection exercises historical EVENT/EOSE ordering and
+			// live delivery after closing and reusing the subscription ID.
+			started := make(chan context.Context, 1)
+			stream := make(chan *nostr.Event, 1)
+			stream <- &nostr.Event{ID: "history", Kind: 1}
+			storage := &testStorage{queryEvents: func(ctx context.Context, _ nostr.Filter) (chan *nostr.Event, error) {
+				started <- ctx
+				return stream, nil
+			}}
+			srv := startTestRelay(t, &testRelay{storage: storage})
+			defer srv.Shutdown(context.Background())
+			defer close(stream)
+			conn := dialWS(t, srv.Addr)
+			sendJSON(t, conn, []any{"REQ", "sub", nostr.Filter{Kinds: []int{1}, Limit: limit}})
+			if typ, _ := recvMessage(t, conn); typ != "EVENT" {
+				t.Fatalf("got %s, want historical EVENT", typ)
+			}
+			queryCtx := <-started
+			sendJSON(t, conn, []any{"CLOSE", "sub"})
+			select {
+			case <-queryCtx.Done():
+			case <-time.After(time.Second):
+				t.Fatal("unfinished stream was not canceled")
+			}
+			// Keep the old stream open: neither receiving nor draining it may
+			// prevent a new subscription on this connection from becoming live.
+			sendJSON(t, conn, []any{"REQ", "sub", map[string]any{"kinds": []int{2}, "limit": 0}})
+			if typ, _ := recvMessage(t, conn); typ != "EOSE" {
+				t.Fatalf("got %s, want replacement EOSE", typ)
+			}
+			waitForRequestState(t, srv, func() bool {
+				for ws, subs := range srv.listeners {
+					if listener := subs["sub"]; listener != nil && len(ws.requests) == 0 {
+						return len(listener.filters) == 1 && listener.filters[0].Kinds[0] == 2
+					}
+				}
+				return false
+			})
+			srv.notifyListeners(&nostr.Event{ID: "live", Kind: 2})
+			typ, raw := recvMessage(t, conn)
+			if typ != "EVENT" {
+				t.Fatalf("got %s, want live EVENT after EOSE", typ)
+			}
+			var event nostr.Event
+			if err := json.Unmarshal(raw[2], &event); err != nil || event.ID != "live" {
+				t.Fatalf("unexpected live event: %s (%v)", raw[2], err)
+			}
+			conn.Close()
+			waitForRequestState(t, srv, func() bool { return len(srv.listeners) == 0 })
+		})
+	}
+}
+
+func TestCanceledHistoryWorkerExitsWithoutChannelClose(t *testing.T) {
+	srv := newListenerTestServer()
+	srv.options = DefaultOptions()
+	srv.relay = &testRelay{}
+	ws := &WebSocket{}
+	req := srv.beginRequest(context.Background(), ws, "sub")
+	stream := make(chan *nostr.Event)
+	defer close(stream)
+	started := make(chan struct{})
+	storage := &testStorage{queryEvents: func(context.Context, nostr.Filter) (chan *nostr.Event, error) {
+		close(started)
+		return stream, nil
+	}}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.doReq(req.ctx, ws, []json.RawMessage{json.RawMessage(`"REQ"`), json.RawMessage(`"sub"`), json.RawMessage(`{"kinds":[1]}`)}, storage, req)
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("history query did not start")
+	}
+	srv.removeListenerId(ws, "sub")
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("canceled history worker is still retaining the request")
+	}
+	if totalConnections(srv) != 0 || len(ws.requests) != 0 {
+		t.Fatal("canceled history retained subscription state")
+	}
+}
+
+// The predicate runs under the lock protecting listeners and pending requests.
+func waitForRequestState(t *testing.T, srv *Server, ready func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		srv.listenersMu.RLock()
+		ok := ready()
+		srv.listenersMu.RUnlock()
+		if ok {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("subscription state did not settle")
+}
+
+func TestReplacementCancelsPendingHistory(t *testing.T) {
+	testPendingHistoryCancellation(t, "REQ")
+}
+
+func testPendingHistoryCancellation(t *testing.T, operation string) {
+	t.Helper()
+	started := make(chan context.Context, 1)
+	release := make(chan struct{})
+	storage := &testStorage{queryEvents: func(ctx context.Context, filter nostr.Filter) (chan *nostr.Event, error) {
+		started <- ctx
+		// Keep the query in flight until the test releases it, even after
+		// cancellation, to model a backend that completes late.
+		<-release
+		ch := make(chan *nostr.Event)
+		close(ch)
+		return ch, nil
+	}}
+	srv := startTestRelay(t, &testRelay{storage: storage})
+	defer srv.Shutdown(context.Background())
+	defer close(release)
+	conn := dialWS(t, srv.Addr)
+	sendJSON(t, conn, []any{"REQ", "sub", nostr.Filter{Kinds: []int{1}}})
+	var queryCtx context.Context
+	select {
+	case queryCtx = <-started:
+	case <-time.After(3 * time.Second):
+		t.Fatal("history query did not start")
+	}
+	if operation == "CLOSE" {
+		sendJSON(t, conn, []any{"CLOSE", "sub"})
+	} else {
+		sendJSON(t, conn, []any{"REQ", "sub", map[string]any{"kinds": []int{2}, "limit": 0}})
+		if typ, _ := recvMessage(t, conn); typ != "EOSE" {
+			t.Fatalf("replacement: got %s, want EOSE", typ)
+		}
+	}
+	select {
+	case <-queryCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatalf("%s did not cancel the pending history query on the open connection", operation)
+	}
+}

--- a/websocket.go
+++ b/websocket.go
@@ -13,6 +13,7 @@ type WebSocket struct {
 
 	// Protected by Server.listenersMu. Disconnect permanently forbids new listeners.
 	disconnected bool
+	requests     map[string]*subscriptionRequest
 
 	// nip42
 	challenge string


### PR DESCRIPTION
Follow up to #161: a history query could restore a subscription after CLOSE on an open connection, or overwrite a newer REQ with the same ID. Reserve request tokens in WebSocket receive order, cancel superseded queries, and reject stale registrations without retaining closed IDs. Regression coverage includes late completion, unfinished streams, disconnect cleanup, and EOSE followed by live delivery after ID reuse.

`go test ./...`, `go vet ./...`, and 10 focused race-test runs pass; both cancellation regressions fail before the fix. The full race run reports existing go-nostr shutdown races in `TestServerShutdownWebsocket`, also reproduced on unchanged master (`f583438`).
